### PR TITLE
Add Phase 1 benchmark harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,62 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +140,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +183,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,16 +201,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "copperdb"
 version = "0.1.0"
 dependencies = [
  "async-trait",
  "axum",
  "bloomfilter",
+ "clap",
  "crc32fast",
  "crossbeam-skiplist",
+ "hdrhistogram",
  "http-body-util",
  "proptest",
+ "rand",
+ "rand_distr",
  "thiserror",
  "tokio",
  "tower",
@@ -155,6 +273,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -203,6 +330,16 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -312,6 +449,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64",
+ "byteorder",
+ "crossbeam-channel",
+ "flate2",
+ "nom",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +567,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +599,12 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -474,6 +637,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,12 +664,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -498,6 +688,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "percent-encoding"
@@ -612,6 +808,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -748,6 +954,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,6 +986,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -916,6 +1134,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ bloomfilter = "3.0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "sync", "time"] }
 axum = "0.8"
 async-trait = "0.1"
+hdrhistogram = "7"
+rand = "0.9"
+rand_distr = "0.5"
+clap = { version = "4", features = ["derive"] }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -1,0 +1,179 @@
+//! Phase 1 of the copperdb benchmark harness.
+//!
+//! Single-threaded driver:
+//!   1. Load phase — insert `--keys` keys with fixed-size random values.
+//!   2. Run phase  — for `--duration` seconds, sample a uniform key and do
+//!                   a get (with probability `--read-pct`) or a put.
+//! Reports throughput plus a latency histogram via hdrhistogram.
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use clap::Parser;
+use hdrhistogram::Histogram;
+use rand::{Rng, SeedableRng};
+use rand::rngs::SmallRng;
+
+use copperdb::engine::LsmEngine;
+
+#[derive(Parser, Debug)]
+#[command(name = "bench", about = "Rust-native benchmark harness for copperdb")]
+struct Args {
+    /// Data directory for the engine. Created if missing.
+    #[arg(long)]
+    dir: PathBuf,
+
+    /// Number of keys to load before the run phase.
+    #[arg(long, default_value_t = 100_000)]
+    keys: u64,
+
+    /// How long the run phase lasts, in seconds.
+    #[arg(long, default_value_t = 30)]
+    duration: u64,
+
+    /// Fraction of run-phase ops that are reads (0.0–1.0); the rest are writes.
+    #[arg(long, default_value_t = 0.5)]
+    read_pct: f64,
+
+    /// Size of each value, in bytes.
+    #[arg(long, default_value_t = 1024)]
+    value_size: usize,
+
+    /// PRNG seed (set for reproducible runs).
+    #[arg(long, default_value_t = 42)]
+    seed: u64,
+
+    /// Seconds to sleep between load and run phases so background flushes /
+    /// compactions drain. Set to 0 to disable.
+    #[arg(long, default_value_t = 1)]
+    cooldown: u64,
+
+    /// Memtable size in bytes. Default 200 KB to stay under the current
+    /// 4 KB SSTable index-block limit (each flush produces ~50 data blocks).
+    /// Raise this once the SSTable writer supports multi-level indices.
+    #[arg(long, default_value_t = 200 * 1024)]
+    memtable_size: usize,
+}
+
+fn make_key(i: u64) -> String {
+    format!("key_{:020}", i)
+}
+
+fn make_value(rng: &mut SmallRng, size: usize, buf: &mut Vec<u8>) {
+    buf.resize(size, 0);
+    rng.fill(&mut buf[..]);
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    if !(0.0..=1.0).contains(&args.read_pct) {
+        return Err(format!("--read-pct must be in [0.0, 1.0], got {}", args.read_pct).into());
+    }
+
+    std::fs::create_dir_all(&args.dir)?;
+    eprintln!("[bench] opening copperdb at {:?} (memtable={} B)", args.dir, args.memtable_size);
+    let engine: std::sync::Arc<LsmEngine> =
+        LsmEngine::open_with_memtable_size(&args.dir, args.memtable_size)?;
+
+    let mut rng = SmallRng::seed_from_u64(args.seed);
+    let mut value_buf: Vec<u8> = Vec::with_capacity(args.value_size);
+
+    // ---- Load phase -----------------------------------------------------
+    eprintln!("[bench] load phase: inserting {} keys", args.keys);
+    let load_start = Instant::now();
+    for i in 0..args.keys {
+        make_value(&mut rng, args.value_size, &mut value_buf);
+        engine.put(make_key(i), value_buf.clone())?;
+    }
+    let load_elapsed = load_start.elapsed();
+    let load_throughput = args.keys as f64 / load_elapsed.as_secs_f64();
+    eprintln!(
+        "[bench] load complete in {:.2}s ({:.0} ops/sec)",
+        load_elapsed.as_secs_f64(),
+        load_throughput,
+    );
+
+    if args.cooldown > 0 {
+        eprintln!("[bench] cooldown {}s (let background work drain)", args.cooldown);
+        std::thread::sleep(Duration::from_secs(args.cooldown));
+    }
+
+    // ---- Run phase ------------------------------------------------------
+    eprintln!(
+        "[bench] run phase: {}s @ read_pct={} value_size={}",
+        args.duration, args.read_pct, args.value_size,
+    );
+
+    // Auto-resizing histogram with 3 significant figures; tracks
+    // latencies in nanoseconds.
+    let mut hist: Histogram<u64> = Histogram::new(3)?;
+
+    let run_start = Instant::now();
+    let run_deadline = run_start + Duration::from_secs(args.duration);
+    let mut total_reads = 0u64;
+    let mut total_writes = 0u64;
+    let mut read_hits = 0u64;
+
+    while Instant::now() < run_deadline {
+        let key_idx = rng.random_range(0..args.keys);
+        let key = make_key(key_idx);
+        let is_read = rng.random::<f64>() < args.read_pct;
+
+        let op_start = Instant::now();
+        if is_read {
+            let got = engine.get(&key);
+            let elapsed_ns = op_start.elapsed().as_nanos() as u64;
+            hist.record(elapsed_ns)?;
+            if got.is_some() {
+                read_hits += 1;
+            }
+            total_reads += 1;
+        } else {
+            make_value(&mut rng, args.value_size, &mut value_buf);
+            engine.put(key, value_buf.clone())?;
+            let elapsed_ns = op_start.elapsed().as_nanos() as u64;
+            hist.record(elapsed_ns)?;
+            total_writes += 1;
+        }
+    }
+    let run_elapsed = run_start.elapsed();
+    let total_ops = total_reads + total_writes;
+
+    // ---- Report ---------------------------------------------------------
+    println!("--- summary ---");
+    println!("config:");
+    println!("  dir:         {:?}", args.dir);
+    println!("  keys:        {}", args.keys);
+    println!("  duration:    {}s", args.duration);
+    println!("  read_pct:    {}", args.read_pct);
+    println!("  value_size:  {} B", args.value_size);
+    println!("  memtable:    {} B", args.memtable_size);
+    println!("  seed:        {}", args.seed);
+    println!();
+    println!("load:");
+    println!("  elapsed:     {:.2}s", load_elapsed.as_secs_f64());
+    println!("  throughput:  {:.0} ops/sec", load_throughput);
+    println!();
+    println!("run:");
+    println!("  elapsed:     {:.2}s", run_elapsed.as_secs_f64());
+    println!("  total ops:   {}", total_ops);
+    println!("  reads:       {} (hits {}, miss rate {:.4})",
+        total_reads,
+        read_hits,
+        if total_reads == 0 { 0.0 } else { 1.0 - (read_hits as f64 / total_reads as f64) },
+    );
+    println!("  writes:      {}", total_writes);
+    println!("  throughput:  {:.0} ops/sec", total_ops as f64 / run_elapsed.as_secs_f64());
+    println!();
+    println!("latency (ns, all ops):");
+    println!("  p50:    {:>12}", hist.value_at_quantile(0.50));
+    println!("  p95:    {:>12}", hist.value_at_quantile(0.95));
+    println!("  p99:    {:>12}", hist.value_at_quantile(0.99));
+    println!("  p99.9:  {:>12}", hist.value_at_quantile(0.999));
+    println!("  p99.99: {:>12}", hist.value_at_quantile(0.9999));
+    println!("  max:    {:>12}", hist.max());
+    println!("  mean:   {:>12.0}", hist.mean());
+
+    Ok(())
+}

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -105,7 +105,11 @@ impl LsmEngine {
         Self::open_with_memtable_size(dir, MAX_MEMTABLE_SIZE)
     }
 
-    pub(crate) fn open_with_memtable_size(
+    /// Open with a non-default memtable byte budget. The default
+    /// `MAX_MEMTABLE_SIZE` is 64 MB; tests and the benchmark harness use
+    /// smaller values to drive flushes/compactions with workloads that fit
+    /// in a reasonable wall-clock time.
+    pub fn open_with_memtable_size(
         dir: &Path,
         memtable_size: usize,
     ) -> io::Result<Arc<Self>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod core;
+pub mod engine;
+pub mod memtable;
+pub mod sstable;
+pub mod wal;
+pub mod compaction;
+pub mod versioning;
+pub mod flusher;
+pub mod server;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,9 @@
-mod core;
-mod engine;
-mod memtable;
-mod sstable;
-mod wal;
-mod compaction;
-mod versioning;
-mod flusher;
-mod server;
-
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::core::StorageEngine;
-use crate::engine::{LsmEngine, LsmHandle};
+use copperdb::core::StorageEngine;
+use copperdb::engine::{LsmEngine, LsmHandle};
+use copperdb::server;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
Introduces a Rust-native benchmark harness as a second binary in the crate. Phase 1 is the smallest useful driver: load N keys, run a configurable read/write mix for a duration, report throughput and a latency histogram via hdrhistogram.

Required converting the crate into a library + binary so the bench binary can reuse engine code. Adds src/lib.rs exposing the existing modules as pub, trims src/main.rs to import via copperdb::* instead of crate::*. Promotes LsmEngine::open_with_memtable_size from pub(crate) to pub so the harness can configure the memtable budget (needed today because the SSTable index block is single-level and overflows under the default 64 MB memtable).

Phase 1 already surfaced a real engine bug: at high distinct-key cardinality, L0→L1 compaction repeatedly fails with "Index block exceeded TARGET_BLOCK_SIZE; multi-level index required". The stress tests didn't catch this because they hammer a 30–50 key pool, so compaction outputs stay tiny after dedup. The bench's 5,000-key workload makes the math explode immediately.