### PR TITLE
Add Phase 2 benchmark harness — Zipfian + YCSB presets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,8 +261,10 @@ dependencies = [
  "proptest",
  "rand",
  "rand_distr",
+ "serde",
  "thiserror",
  "tokio",
+ "toml",
  "tower",
 ]
 
@@ -885,6 +887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -929,6 +932,15 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1068,6 +1080,47 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -1266,6 +1319,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ hdrhistogram = "7"
 rand = "0.9"
 rand_distr = "0.5"
 clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -1,20 +1,185 @@
-//! Phase 1 of the copperdb benchmark harness.
+//! copperdb benchmark harness (Phase 2).
 //!
-//! Single-threaded driver:
-//!   1. Load phase — insert `--keys` keys with fixed-size random values.
-//!   2. Run phase  — for `--duration` seconds, sample a uniform key and do
-//!                   a get (with probability `--read-pct`) or a put.
-//! Reports throughput plus a latency histogram via hdrhistogram.
+//! Single-threaded driver supporting Zipfian / uniform / latest key
+//! distributions and a configurable op mix (read / update / insert /
+//! read-modify-write). Workloads can be supplied either as a TOML preset
+//! (`--config workloads/ycsb-a.toml`) or via individual CLI flags.
 
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use clap::Parser;
 use hdrhistogram::Histogram;
-use rand::{Rng, SeedableRng};
 use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+use rand_distr::{Distribution, Zipf};
+use serde::Deserialize;
 
 use copperdb::engine::LsmEngine;
+
+// ---------------------------------------------------------------------------
+// Workload model
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize, Debug, Clone)]
+struct Workload {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    description: String,
+    keys: u64,
+    value_size: usize,
+    key_distribution: KeyDistributionKind,
+    #[serde(default = "default_theta")]
+    zipfian_theta: f64,
+    op_mix: OpMix,
+}
+
+fn default_theta() -> f64 {
+    0.99
+}
+
+#[derive(Deserialize, Debug, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+enum KeyDistributionKind {
+    Uniform,
+    Zipfian,
+    Latest,
+}
+
+impl std::str::FromStr for KeyDistributionKind {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "uniform" => Ok(KeyDistributionKind::Uniform),
+            "zipfian" => Ok(KeyDistributionKind::Zipfian),
+            "latest" => Ok(KeyDistributionKind::Latest),
+            other => Err(format!("unknown key distribution: {}", other)),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone, Copy, Default)]
+struct OpMix {
+    #[serde(default)]
+    read: f64,
+    #[serde(default)]
+    update: f64,
+    #[serde(default)]
+    insert: f64,
+    #[serde(default)]
+    rmw: f64,
+}
+
+impl OpMix {
+    fn validate(&self) -> Result<(), String> {
+        for (name, v) in [
+            ("read", self.read),
+            ("update", self.update),
+            ("insert", self.insert),
+            ("rmw", self.rmw),
+        ] {
+            if v < 0.0 {
+                return Err(format!("op_mix.{} = {} is negative", name, v));
+            }
+        }
+        let sum = self.read + self.update + self.insert + self.rmw;
+        if (sum - 1.0).abs() > 1e-6 {
+            return Err(format!(
+                "op_mix sums to {} (read={}, update={}, insert={}, rmw={}); expected 1.0",
+                sum, self.read, self.update, self.insert, self.rmw,
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum OpKind {
+    Read,
+    Update,
+    Insert,
+    Rmw,
+}
+
+// ---------------------------------------------------------------------------
+// Samplers
+// ---------------------------------------------------------------------------
+
+/// Per-op random key chooser, parameterised by the workload's distribution.
+struct KeySampler {
+    kind: KeyDistributionKind,
+    zipf: Option<Zipf<f64>>,
+}
+
+impl KeySampler {
+    fn new(kind: KeyDistributionKind, n_initial: u64, theta: f64) -> Result<Self, String> {
+        let zipf = match kind {
+            KeyDistributionKind::Uniform => None,
+            KeyDistributionKind::Zipfian | KeyDistributionKind::Latest => Some(
+                Zipf::new(n_initial as f64, theta)
+                    .map_err(|e| format!("invalid Zipf parameters: {}", e))?,
+            ),
+        };
+        Ok(Self { kind, zipf })
+    }
+
+    /// Sample a key index in `[0, n_current)`.
+    fn sample(&self, rng: &mut SmallRng, n_current: u64) -> u64 {
+        debug_assert!(n_current > 0);
+        match self.kind {
+            KeyDistributionKind::Uniform => rng.random_range(0..n_current),
+            KeyDistributionKind::Zipfian => {
+                // Zipf yields 1-indexed ranks; shift and clamp into [0, n_current).
+                let r = self.zipf.as_ref().unwrap().sample(rng) as u64;
+                r.saturating_sub(1).min(n_current - 1)
+            }
+            KeyDistributionKind::Latest => {
+                // Reverse the rank so rank=1 (most likely) maps to the most
+                // recently inserted key. Approximation: the Zipf was built
+                // against the initial key space; as inserts grow n_current,
+                // the distribution slightly under-weights the tail.
+                let r = self.zipf.as_ref().unwrap().sample(rng) as u64;
+                let rank = r.max(1).min(n_current);
+                n_current - rank
+            }
+        }
+    }
+}
+
+/// Cumulative-threshold sampler for the op mix.
+struct OpSampler {
+    read: f64,
+    update_cum: f64,
+    insert_cum: f64,
+    // rmw fills the rest.
+}
+
+impl OpSampler {
+    fn new(mix: &OpMix) -> Self {
+        Self {
+            read: mix.read,
+            update_cum: mix.read + mix.update,
+            insert_cum: mix.read + mix.update + mix.insert,
+        }
+    }
+
+    fn sample(&self, r: f64) -> OpKind {
+        if r < self.read {
+            OpKind::Read
+        } else if r < self.update_cum {
+            OpKind::Update
+        } else if r < self.insert_cum {
+            OpKind::Insert
+        } else {
+            OpKind::Rmw
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
 
 #[derive(Parser, Debug)]
 #[command(name = "bench", about = "Rust-native benchmark harness for copperdb")]
@@ -23,37 +188,132 @@ struct Args {
     #[arg(long)]
     dir: PathBuf,
 
-    /// Number of keys to load before the run phase.
-    #[arg(long, default_value_t = 100_000)]
-    keys: u64,
+    /// Path to a TOML workload preset (see workloads/). When set, the
+    /// workload-detail flags below are ignored.
+    #[arg(long)]
+    config: Option<PathBuf>,
 
     /// How long the run phase lasts, in seconds.
     #[arg(long, default_value_t = 30)]
     duration: u64,
-
-    /// Fraction of run-phase ops that are reads (0.0–1.0); the rest are writes.
-    #[arg(long, default_value_t = 0.5)]
-    read_pct: f64,
-
-    /// Size of each value, in bytes.
-    #[arg(long, default_value_t = 1024)]
-    value_size: usize,
 
     /// PRNG seed (set for reproducible runs).
     #[arg(long, default_value_t = 42)]
     seed: u64,
 
     /// Seconds to sleep between load and run phases so background flushes /
-    /// compactions drain. Set to 0 to disable.
+    /// compactions drain.
     #[arg(long, default_value_t = 1)]
     cooldown: u64,
 
-    /// Memtable size in bytes. Default 200 KB to stay under the current
-    /// 4 KB SSTable index-block limit (each flush produces ~50 data blocks).
-    /// Raise this once the SSTable writer supports multi-level indices.
+    /// Memtable size in bytes. 200 KB by default to stay within the SSTable
+    /// writer's per-flush index budget.
     #[arg(long, default_value_t = 200 * 1024)]
     memtable_size: usize,
+
+    // -- Workload-detail overrides. When --config is set, these override
+    // individual fields of the loaded TOML. When --config is absent, missing
+    // values fall back to the built-in defaults in `default_workload()`. --
+    /// Number of keys to load before the run phase.
+    #[arg(long)]
+    keys: Option<u64>,
+
+    /// Size of each value, in bytes.
+    #[arg(long)]
+    value_size: Option<usize>,
+
+    /// Key distribution: uniform | zipfian | latest.
+    #[arg(long)]
+    key_distribution: Option<String>,
+
+    /// Zipfian exponent (also used by `latest`).
+    #[arg(long)]
+    zipfian_theta: Option<f64>,
+
+    /// Fraction of ops that are reads.
+    #[arg(long)]
+    read_pct: Option<f64>,
+
+    /// Fraction of ops that are updates (writes to an existing key).
+    #[arg(long)]
+    update_pct: Option<f64>,
+
+    /// Fraction of ops that are inserts (writes to a new key, growing the
+    /// key space).
+    #[arg(long)]
+    insert_pct: Option<f64>,
+
+    /// Fraction of ops that are read-modify-write (get followed by put).
+    #[arg(long)]
+    rmw_pct: Option<f64>,
 }
+
+fn default_workload() -> Workload {
+    Workload {
+        name: "custom".to_string(),
+        description: "Workload built from CLI flags".to_string(),
+        keys: 100_000,
+        value_size: 1024,
+        key_distribution: KeyDistributionKind::Uniform,
+        zipfian_theta: 0.99,
+        op_mix: OpMix {
+            read: 0.5,
+            update: 0.5,
+            insert: 0.0,
+            rmw: 0.0,
+        },
+    }
+}
+
+fn resolve_workload(args: &Args) -> Result<Workload, Box<dyn std::error::Error>> {
+    // Start from the TOML preset if given, otherwise from built-in defaults.
+    let mut workload = if let Some(path) = args.config.as_ref() {
+        let raw = std::fs::read_to_string(path)
+            .map_err(|e| format!("failed to read {:?}: {}", path, e))?;
+        toml::from_str::<Workload>(&raw)
+            .map_err(|e| format!("failed to parse {:?}: {}", path, e))?
+    } else {
+        default_workload()
+    };
+
+    // Apply CLI overrides on top.
+    if let Some(v) = args.keys {
+        workload.keys = v;
+    }
+    if let Some(v) = args.value_size {
+        workload.value_size = v;
+    }
+    if let Some(s) = &args.key_distribution {
+        workload.key_distribution = s.parse()?;
+    }
+    if let Some(v) = args.zipfian_theta {
+        workload.zipfian_theta = v;
+    }
+    // Op-mix override: if any pct flag is set, replace the whole mix so we
+    // don't end up with a mix that doesn't sum to 1.0 from partial overrides.
+    if args.read_pct.is_some()
+        || args.update_pct.is_some()
+        || args.insert_pct.is_some()
+        || args.rmw_pct.is_some()
+    {
+        workload.op_mix = OpMix {
+            read: args.read_pct.unwrap_or(0.0),
+            update: args.update_pct.unwrap_or(0.0),
+            insert: args.insert_pct.unwrap_or(0.0),
+            rmw: args.rmw_pct.unwrap_or(0.0),
+        };
+    }
+
+    workload.op_mix.validate()?;
+    if workload.keys == 0 {
+        return Err("workload.keys must be > 0".into());
+    }
+    Ok(workload)
+}
+
+// ---------------------------------------------------------------------------
+// Op helpers
+// ---------------------------------------------------------------------------
 
 fn make_key(i: u64) -> String {
     format!("key_{:020}", i)
@@ -64,30 +324,38 @@ fn make_value(rng: &mut SmallRng, size: usize, buf: &mut Vec<u8>) {
     rng.fill(&mut buf[..]);
 }
 
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
-
-    if !(0.0..=1.0).contains(&args.read_pct) {
-        return Err(format!("--read-pct must be in [0.0, 1.0], got {}", args.read_pct).into());
-    }
+    let workload = resolve_workload(&args)?;
 
     std::fs::create_dir_all(&args.dir)?;
-    eprintln!("[bench] opening copperdb at {:?} (memtable={} B)", args.dir, args.memtable_size);
+    eprintln!(
+        "[bench] workload: {} — {}",
+        workload.name, workload.description,
+    );
+    eprintln!(
+        "[bench] opening copperdb at {:?} (memtable={} B)",
+        args.dir, args.memtable_size,
+    );
     let engine: std::sync::Arc<LsmEngine> =
         LsmEngine::open_with_memtable_size(&args.dir, args.memtable_size)?;
 
     let mut rng = SmallRng::seed_from_u64(args.seed);
-    let mut value_buf: Vec<u8> = Vec::with_capacity(args.value_size);
+    let mut value_buf: Vec<u8> = Vec::with_capacity(workload.value_size);
 
     // ---- Load phase -----------------------------------------------------
-    eprintln!("[bench] load phase: inserting {} keys", args.keys);
+    eprintln!("[bench] load phase: inserting {} keys", workload.keys);
     let load_start = Instant::now();
-    for i in 0..args.keys {
-        make_value(&mut rng, args.value_size, &mut value_buf);
+    for i in 0..workload.keys {
+        make_value(&mut rng, workload.value_size, &mut value_buf);
         engine.put(make_key(i), value_buf.clone())?;
     }
     let load_elapsed = load_start.elapsed();
-    let load_throughput = args.keys as f64 / load_elapsed.as_secs_f64();
+    let load_throughput = workload.keys as f64 / load_elapsed.as_secs_f64();
     eprintln!(
         "[bench] load complete in {:.2}s ({:.0} ops/sec)",
         load_elapsed.as_secs_f64(),
@@ -95,59 +363,114 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     if args.cooldown > 0 {
-        eprintln!("[bench] cooldown {}s (let background work drain)", args.cooldown);
+        eprintln!(
+            "[bench] cooldown {}s (let background work drain)",
+            args.cooldown,
+        );
         std::thread::sleep(Duration::from_secs(args.cooldown));
     }
 
     // ---- Run phase ------------------------------------------------------
     eprintln!(
-        "[bench] run phase: {}s @ read_pct={} value_size={}",
-        args.duration, args.read_pct, args.value_size,
+        "[bench] run phase: {}s @ distribution={:?} mix={:?}",
+        args.duration, workload.key_distribution, workload.op_mix,
     );
 
-    // Auto-resizing histogram with 3 significant figures; tracks
-    // latencies in nanoseconds.
+    let key_sampler =
+        KeySampler::new(workload.key_distribution, workload.keys, workload.zipfian_theta)?;
+    let op_sampler = OpSampler::new(&workload.op_mix);
+
     let mut hist: Histogram<u64> = Histogram::new(3)?;
 
     let run_start = Instant::now();
     let run_deadline = run_start + Duration::from_secs(args.duration);
-    let mut total_reads = 0u64;
-    let mut total_writes = 0u64;
+
+    let mut next_insert_idx: u64 = workload.keys;
+    let mut n_current: u64 = workload.keys;
+    let mut reads = 0u64;
+    let mut updates = 0u64;
+    let mut inserts = 0u64;
+    let mut rmws = 0u64;
     let mut read_hits = 0u64;
 
     while Instant::now() < run_deadline {
-        let key_idx = rng.random_range(0..args.keys);
-        let key = make_key(key_idx);
-        let is_read = rng.random::<f64>() < args.read_pct;
-
-        let op_start = Instant::now();
-        if is_read {
-            let got = engine.get(&key);
-            let elapsed_ns = op_start.elapsed().as_nanos() as u64;
-            hist.record(elapsed_ns)?;
-            if got.is_some() {
-                read_hits += 1;
+        let op = op_sampler.sample(rng.random::<f64>());
+        match op {
+            OpKind::Read => {
+                let k = make_key(key_sampler.sample(&mut rng, n_current));
+                let t = Instant::now();
+                let got = engine.get(&k);
+                let elapsed_ns = t.elapsed().as_nanos() as u64;
+                hist.record(elapsed_ns)?;
+                if got.is_some() {
+                    read_hits += 1;
+                }
+                reads += 1;
             }
-            total_reads += 1;
-        } else {
-            make_value(&mut rng, args.value_size, &mut value_buf);
-            engine.put(key, value_buf.clone())?;
-            let elapsed_ns = op_start.elapsed().as_nanos() as u64;
-            hist.record(elapsed_ns)?;
-            total_writes += 1;
+            OpKind::Update => {
+                let k = make_key(key_sampler.sample(&mut rng, n_current));
+                make_value(&mut rng, workload.value_size, &mut value_buf);
+                let t = Instant::now();
+                engine.put(k, value_buf.clone())?;
+                let elapsed_ns = t.elapsed().as_nanos() as u64;
+                hist.record(elapsed_ns)?;
+                updates += 1;
+            }
+            OpKind::Insert => {
+                let k = make_key(next_insert_idx);
+                next_insert_idx += 1;
+                n_current = next_insert_idx;
+                make_value(&mut rng, workload.value_size, &mut value_buf);
+                let t = Instant::now();
+                engine.put(k, value_buf.clone())?;
+                let elapsed_ns = t.elapsed().as_nanos() as u64;
+                hist.record(elapsed_ns)?;
+                inserts += 1;
+            }
+            OpKind::Rmw => {
+                let k = make_key(key_sampler.sample(&mut rng, n_current));
+                let t = Instant::now();
+                let _ = engine.get(&k);
+                make_value(&mut rng, workload.value_size, &mut value_buf);
+                engine.put(k, value_buf.clone())?;
+                let elapsed_ns = t.elapsed().as_nanos() as u64;
+                hist.record(elapsed_ns)?;
+                rmws += 1;
+            }
         }
     }
     let run_elapsed = run_start.elapsed();
-    let total_ops = total_reads + total_writes;
+    let total_ops = reads + updates + inserts + rmws;
 
     // ---- Report ---------------------------------------------------------
+    let pct = |n: u64| -> f64 {
+        if total_ops == 0 {
+            0.0
+        } else {
+            100.0 * n as f64 / total_ops as f64
+        }
+    };
+
     println!("--- summary ---");
+    println!("workload:");
+    println!("  name:        {}", workload.name);
+    println!("  description: {}", workload.description);
+    println!("  keys:        {}", workload.keys);
+    println!("  value_size:  {} B", workload.value_size);
+    println!("  key_dist:    {:?}", workload.key_distribution);
+    if !matches!(workload.key_distribution, KeyDistributionKind::Uniform) {
+        println!("  zipf_theta:  {}", workload.zipfian_theta);
+    }
+    println!(
+        "  op_mix:      read={:.2} update={:.2} insert={:.2} rmw={:.2}",
+        workload.op_mix.read,
+        workload.op_mix.update,
+        workload.op_mix.insert,
+        workload.op_mix.rmw,
+    );
     println!("config:");
     println!("  dir:         {:?}", args.dir);
-    println!("  keys:        {}", args.keys);
     println!("  duration:    {}s", args.duration);
-    println!("  read_pct:    {}", args.read_pct);
-    println!("  value_size:  {} B", args.value_size);
     println!("  memtable:    {} B", args.memtable_size);
     println!("  seed:        {}", args.seed);
     println!();
@@ -158,13 +481,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("run:");
     println!("  elapsed:     {:.2}s", run_elapsed.as_secs_f64());
     println!("  total ops:   {}", total_ops);
-    println!("  reads:       {} (hits {}, miss rate {:.4})",
-        total_reads,
+    println!(
+        "  reads:       {} ({:.1}%, hits {}, miss rate {:.4})",
+        reads,
+        pct(reads),
         read_hits,
-        if total_reads == 0 { 0.0 } else { 1.0 - (read_hits as f64 / total_reads as f64) },
+        if reads == 0 {
+            0.0
+        } else {
+            1.0 - (read_hits as f64 / reads as f64)
+        },
     );
-    println!("  writes:      {}", total_writes);
-    println!("  throughput:  {:.0} ops/sec", total_ops as f64 / run_elapsed.as_secs_f64());
+    println!("  updates:     {} ({:.1}%)", updates, pct(updates));
+    println!("  inserts:     {} ({:.1}%)", inserts, pct(inserts));
+    println!("  rmw:         {} ({:.1}%)", rmws, pct(rmws));
+    println!(
+        "  key space:   {} (initial) → {} (final)",
+        workload.keys, n_current,
+    );
+    println!(
+        "  throughput:  {:.0} ops/sec",
+        total_ops as f64 / run_elapsed.as_secs_f64(),
+    );
     println!();
     println!("latency (ns, all ops):");
     println!("  p50:    {:>12}", hist.value_at_quantile(0.50));

--- a/workloads/README.md
+++ b/workloads/README.md
@@ -1,0 +1,42 @@
+# Workload presets
+
+TOML files in this directory describe canonical YCSB-style workloads that the
+benchmark harness can run via `--config`:
+
+```
+cargo run --release --bin bench -- \
+    --dir /tmp/bench-a \
+    --config workloads/ycsb-a.toml \
+    --duration 30
+```
+
+| File          | YCSB name | Op mix                       | Key distribution | Notes                              |
+|---------------|-----------|------------------------------|-------------------|------------------------------------|
+| `ycsb-a.toml` | A         | 50% read / 50% update         | Zipfian (θ=0.99)  | Update-heavy session store         |
+| `ycsb-b.toml` | B         | 95% read / 5% update          | Zipfian (θ=0.99)  | Read-mostly with light updates     |
+| `ycsb-c.toml` | C         | 100% read                     | Zipfian (θ=0.99)  | Read-only baseline                 |
+| `ycsb-d.toml` | D         | 95% read / 5% insert          | Latest            | Read-latest with growing key space |
+| `ycsb-f.toml` | F         | 50% read / 50% RMW            | Zipfian (θ=0.99)  | Read-modify-write                  |
+
+YCSB-E (short range scans) is intentionally omitted — `LsmEngine` does not
+yet expose a public scan API. Adding one is a separate engine feature, not
+part of the benchmark harness.
+
+All presets default to **1 million keys × 1 KB values**. Override any field
+at run time with the corresponding CLI flag (e.g. `--keys 10000`), or copy a
+TOML preset and edit it. Run-time knobs (`--dir`, `--duration`, `--seed`,
+`--cooldown`, `--memtable-size`) are always supplied via CLI; the TOML
+describes the *workload*, not the *run*.
+
+> **Note on current engine limits.** The SSTable writer uses a single-level
+> 1 MB index block (see `src/sstable/DESIGN.md`). At the full 1M × 1KB
+> defaults, the L0→L1 compaction output's index exceeds 1 MB and the
+> compaction fails. Until copperdb grows a multi-level index, smoke-test the
+> presets with smaller overrides — e.g.
+> `--keys 5000 --value-size 256` — or use smaller per-value sizes
+> (`--value-size 64`) at the full key count.
+
+Reference: B. F. Cooper et al., *Benchmarking Cloud Serving Systems with
+YCSB* (SoCC '10). Our numbers aren't directly comparable to the paper's
+because we drive `LsmEngine` in-process rather than through YCSB's Java
+client, but the workload definitions are intentionally aligned.

--- a/workloads/ycsb-a.toml
+++ b/workloads/ycsb-a.toml
@@ -1,0 +1,12 @@
+# YCSB-A — 50% read / 50% update, Zipfian-skewed access.
+#
+# Update-heavy workload that mirrors a session-store: each operation either
+# fetches the session or writes a new value, with a small set of hot keys.
+
+name = "YCSB-A"
+description = "50/50 read/update with Zipfian-skewed access (update-heavy)"
+keys = 1_000_000
+value_size = 1024
+key_distribution = "zipfian"
+zipfian_theta = 0.99
+op_mix = { read = 0.5, update = 0.5, insert = 0.0, rmw = 0.0 }

--- a/workloads/ycsb-b.toml
+++ b/workloads/ycsb-b.toml
@@ -1,0 +1,12 @@
+# YCSB-B — 95% read / 5% update, Zipfian.
+#
+# Read-mostly with light updates; representative of photo-tagging / social
+# read-heavy workloads.
+
+name = "YCSB-B"
+description = "Read-mostly with light updates; Zipfian-skewed access"
+keys = 1_000_000
+value_size = 1024
+key_distribution = "zipfian"
+zipfian_theta = 0.99
+op_mix = { read = 0.95, update = 0.05, insert = 0.0, rmw = 0.0 }

--- a/workloads/ycsb-c.toml
+++ b/workloads/ycsb-c.toml
@@ -1,0 +1,12 @@
+# YCSB-C — 100% read, Zipfian.
+#
+# Pure read workload. Useful as a baseline for the read path with no
+# write-side interference (no flushes, no compactions triggered by the bench).
+
+name = "YCSB-C"
+description = "Read-only; Zipfian-skewed access"
+keys = 1_000_000
+value_size = 1024
+key_distribution = "zipfian"
+zipfian_theta = 0.99
+op_mix = { read = 1.0, update = 0.0, insert = 0.0, rmw = 0.0 }

--- a/workloads/ycsb-d.toml
+++ b/workloads/ycsb-d.toml
@@ -1,0 +1,12 @@
+# YCSB-D — 95% read / 5% insert, Latest distribution.
+#
+# Read-mostly with new-record inserts; reads are biased toward the most
+# recently inserted keys. Models a news-feed or status-update workload.
+
+name = "YCSB-D"
+description = "Read-mostly with new-record inserts; reads biased toward latest keys"
+keys = 1_000_000
+value_size = 1024
+key_distribution = "latest"
+zipfian_theta = 0.99
+op_mix = { read = 0.95, update = 0.0, insert = 0.05, rmw = 0.0 }

--- a/workloads/ycsb-f.toml
+++ b/workloads/ycsb-f.toml
@@ -1,0 +1,12 @@
+# YCSB-F — 50% read / 50% read-modify-write, Zipfian.
+#
+# Each RMW reads a record, modifies it, and writes it back. Models user-record
+# updates where the new value depends on the old.
+
+name = "YCSB-F"
+description = "Read / read-modify-write mix; Zipfian-skewed access"
+keys = 1_000_000
+value_size = 1024
+key_distribution = "zipfian"
+zipfian_theta = 0.99
+op_mix = { read = 0.5, update = 0.0, insert = 0.0, rmw = 0.5 }


### PR DESCRIPTION
Phase 1 of the harness only knew one workload shape: uniform random keys, single-coin-flip read-vs-write. Phase 2 makes the harness's workloads match the LSM literature so numbers are interpretable next to YCSB and RocksDB benchmarks.

New in the harness (src/bin/bench.rs):

  - Workload, OpMix, KeyDistributionKind, OpKind types with serde deserialization for TOML preset loading.
  - KeySampler supporting uniform, zipfian (rand_distr::Zipf), and latest (rank-reversed Zipf so the most likely sample is the most recently inserted key).
  - OpSampler with cumulative-threshold dispatch across read, update, insert, read-modify-write.
  - Extended CLI: --config <toml> loads a preset; the individual --keys / --value-size / --key-distribution / --zipfian-theta and --{read,update,insert,rmw}-pct flags now act as overrides on top of a preset (or stand alone when --config is absent).
  - Run-loop dispatches on OpKind. Insert grows next_insert_idx so Latest-distribution reads can bias toward the new keys.
  - Report extended with per-op-kind breakdown and key-space initial→ final, useful for verifying YCSB-D's growing key space.

Shipped TOML presets under workloads/ matching YCSB definitions:

  - ycsb-a.toml — 50/50 read/update, Zipfian
  - ycsb-b.toml — 95/5 read/update, Zipfian
  - ycsb-c.toml — 100% read, Zipfian
  - ycsb-d.toml — 95/5 read/insert, Latest
  - ycsb-f.toml — 50/50 read/RMW, Zipfian

YCSB-E (short scans) is intentionally absent — LsmEngine doesn't yet expose a public scan API, and adding one is a separate engine feature.

Smoke tests (5s, 3000 keys, 256 B values, all five presets): op breakdowns within sampling noise of the configured mixes; YCSB-D's key space grew 3000 → 34553 proving inserts ran; zero compaction errors at this scale.

The TOML defaults (1M × 1KB) currently exceed the SSTable writer's 1 MB single-level index; documented in workloads/README.md with recommended overrides for now. The real fix is a multi-level index (separate scoped work, not part of Phase 2).