### PR TITLE
Two-level SSTable index

### DIFF
--- a/src/bin/README.md
+++ b/src/bin/README.md
@@ -91,10 +91,9 @@ cargo run --release --bin bench -- \
     --keys 5000 --value-size 256 --duration 10
 ```
 
-> **Note on current engine limits.** The TOML presets default to 1 M × 1 KB,
-> which exceeds the SSTable writer's single-level 1 MB index budget during
-> compaction. Smoke the presets with `--keys` / `--value-size` overrides until
-> the engine grows a multi-level index. See `src/sstable/DESIGN.md`.
+The TOML presets default to 1 M × 1 KB, which now works as-is thanks to
+the two-level SSTable index (see `src/sstable/DESIGN.md`). Smaller overrides
+remain useful for quick smoke tests during development.
 
 ## CLI reference
 
@@ -108,7 +107,7 @@ cargo run --release --bin bench -- \
 | `--target-rate <r>` | (open-loop)  | Total ops/sec across all threads. Enables closed-loop + CO correction. |
 | `--seed <u64>`      | `42`         | PRNG seed. Each thread uses `seed + thread_id`.                    |
 | `--cooldown <secs>` | `1`          | Sleep between load and run phases so background work drains.       |
-| `--memtable-size`   | `204800`     | Memtable byte budget. Defaults to 200 KB to fit the index limit.   |
+| `--memtable-size`   | `204800`     | Memtable byte budget. 200 KB default keeps flushes brisk for development; raise for larger runs. |
 
 ### Workload flags (CLI or TOML)
 
@@ -198,5 +197,3 @@ cargo run --release --bin bench -- --dir /tmp/sustain --config workloads/ycsb-c.
   the answer.
 - **No `scan` workload (YCSB-E).** `LsmEngine` has no public `scan` API;
   adding one is a separate engine feature, not part of the harness phasing.
-- **Index-block limit at full preset defaults.** Documented in
-  `workloads/README.md`.

--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -108,50 +108,83 @@ impl SsTableIterator {
             )));
         }
 
-        // Read the index block (sits between meta block and footer).
-        let index_size = file_len
+        // Read the top index block (sits between the last L1 block and the
+        // footer; `index_offset` in the footer now means top-index offset).
+        let top_index_offset = index_offset;
+        let top_index_size = file_len
             .saturating_sub(FOOTER_SIZE as u64)
-            .saturating_sub(index_offset) as usize;
+            .saturating_sub(top_index_offset) as usize;
 
-        file.seek(SeekFrom::Start(index_offset))?;
-        let mut index_data = vec![0u8; index_size];
-        file.read_exact(&mut index_data)?;
+        file.seek(SeekFrom::Start(top_index_offset))?;
+        let mut top_index_data = vec![0u8; top_index_size];
+        file.read_exact(&mut top_index_data)?;
+        let top_index = Block::decode(top_index_data);
 
-        let index_block = Block::decode(index_data);
-        let num_index_entries = index_block
+        // Helper: decode an 8-byte big-endian u64 offset from an index entry.
+        let decode_offset = |record: Record| -> Result<u64, CompactionError> {
+            match record {
+                Record::Put(v) => {
+                    let arr: [u8; 8] = v.try_into().map_err(|_| {
+                        CompactionError::SSTable("Index pointer is not 8 bytes".to_string())
+                    })?;
+                    Ok(u64::from_be_bytes(arr))
+                }
+                Record::Delete => Err(CompactionError::SSTable(
+                    "Index block contains a Delete record".to_string(),
+                )),
+            }
+        };
+
+        // Walk the top index → for each L1 entry, read that L1 block from
+        // disk and collect every data-block offset it points at.
+        let n_top = top_index
             .get_num_offsets()
             .map_err(|e| CompactionError::SSTable(e.to_string()))?;
 
-        // Collect the start byte of each data block from the index.
-        let mut block_starts: Vec<u64> = Vec::with_capacity(num_index_entries);
-        for i in 0..num_index_entries {
-            let entry_offset = index_block
-                .get_offset(i, num_index_entries)
+        let mut block_starts: Vec<u64> = Vec::new();
+        for top_i in 0..n_top {
+            let top_entry_offset = top_index
+                .get_offset(top_i, n_top)
                 .map_err(|e| CompactionError::SSTable(e.to_string()))?;
-
-            let (_, record) = index_block
-                .decode_entry(entry_offset)
+            let (_, top_record) = top_index
+                .decode_entry(top_entry_offset)
                 .map_err(|e| CompactionError::SSTable(e.to_string()))?;
+            let l1_start = decode_offset(top_record)?;
 
-            let block_start = match record {
-                Record::Put(v) => {
-                    let arr: [u8; 8] = v.try_into().map_err(|_| {
-                        CompactionError::SSTable(
-                            "Index block pointer is not 8 bytes".to_string(),
-                        )
-                    })?;
-                    u64::from_be_bytes(arr)
-                }
-                Record::Delete => {
-                    return Err(CompactionError::SSTable(
-                        "Index block contains a Delete record".to_string(),
-                    ));
-                }
+            let l1_end = if top_i + 1 < n_top {
+                let next_top_entry_offset = top_index
+                    .get_offset(top_i + 1, n_top)
+                    .map_err(|e| CompactionError::SSTable(e.to_string()))?;
+                let (_, next_top_record) = top_index
+                    .decode_entry(next_top_entry_offset)
+                    .map_err(|e| CompactionError::SSTable(e.to_string()))?;
+                decode_offset(next_top_record)?
+            } else {
+                top_index_offset
             };
-            block_starts.push(block_start);
+
+            let l1_size = (l1_end - l1_start) as usize;
+            file.seek(SeekFrom::Start(l1_start))?;
+            let mut l1_data = vec![0u8; l1_size];
+            file.read_exact(&mut l1_data)?;
+            let l1_block = Block::decode(l1_data);
+
+            let n_l1 = l1_block
+                .get_num_offsets()
+                .map_err(|e| CompactionError::SSTable(e.to_string()))?;
+            for j in 0..n_l1 {
+                let entry_offset = l1_block
+                    .get_offset(j, n_l1)
+                    .map_err(|e| CompactionError::SSTable(e.to_string()))?;
+                let (_, record) = l1_block
+                    .decode_entry(entry_offset)
+                    .map_err(|e| CompactionError::SSTable(e.to_string()))?;
+                block_starts.push(decode_offset(record)?);
+            }
         }
 
-        // Build (start, end) ranges. The last block ends where the index block begins.
+        // Build (start, end) ranges. The last data block ends where the meta
+        // block begins.
         let mut block_ranges: Vec<(u64, u64)> = Vec::with_capacity(block_starts.len());
         for (i, &start) in block_starts.iter().enumerate() {
             let end = if i + 1 < block_starts.len() {
@@ -736,17 +769,89 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
-    /// A high-cardinality workload — thousands of distinct keys — must
-    /// flush and compact without errors. Pre-Option-B the SSTable index
-    /// block was capped at 4 KB; merging multiple L0 files of distinct
-    /// keys yielded an L1 output whose index overflowed, so compaction
-    /// silently failed and L0 grew unboundedly. The existing stress
-    /// tests miss this because they hammer 30–50 keys repeatedly — after
-    /// dedup, merged outputs are tiny.
+    /// `SsTableIterator` must walk both index levels — it can't assume the
+    /// single-level layout. Builds a file whose L1 index spans multiple
+    /// blocks (enough distinct keys to overflow the 64 KB L1 target), then
+    /// iterates it end-to-end and verifies entry count + sorted order.
+    #[test]
+    fn sstable_iterator_walks_multi_l1() {
+        use std::sync::atomic::AtomicUsize;
+
+        static CNT: AtomicUsize = AtomicUsize::new(0);
+        let id = CNT.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "iter_multi_l1_{}_{}.sst",
+            std::process::id(),
+            id,
+        ));
+
+        struct SliceIter {
+            inner: std::vec::IntoIter<(String, Record, u64)>,
+        }
+        impl KvIterator for SliceIter {
+            fn is_valid(&self) -> bool {
+                false
+            }
+            fn next(&mut self) -> Option<(String, Record, u64)> {
+                self.inner.next()
+            }
+        }
+
+        // 30k entries × 256B values = ~7.5 MB of data → ~7,500 data blocks
+        // → ~370 KB of L1 index → ~6 L1 blocks at the 64 KB L1 target.
+        const NUM_KEYS: u32 = 30_000;
+        const VALUE_SIZE: usize = 256;
+
+        let entries: Vec<(String, Record, u64)> = (0..NUM_KEYS)
+            .map(|i| {
+                (
+                    format!("key_{:020}", i),
+                    Record::Put(vec![(i % 256) as u8; VALUE_SIZE]),
+                    (NUM_KEYS - i) as u64,
+                )
+            })
+            .collect();
+
+        {
+            let mut builder = SsTableBuilder::new(path.to_str().unwrap()).unwrap();
+            builder
+                .build_from_iterator(Box::new(SliceIter {
+                    inner: entries.clone().into_iter(),
+                }))
+                .unwrap();
+        }
+
+        let mut iter = SsTableIterator::open(&path).unwrap();
+        let mut yielded: Vec<(String, u64)> = Vec::new();
+        while let Some((k, _, seq)) = iter.next() {
+            yielded.push((k, seq));
+        }
+
+        assert_eq!(
+            yielded.len(),
+            entries.len(),
+            "iterator must yield every entry across L1 boundaries",
+        );
+
+        // Confirm sorted-by-key order is preserved across L1 boundaries.
+        let expected_keys: Vec<String> =
+            entries.iter().map(|(k, _, _)| k.clone()).collect();
+        let actual_keys: Vec<String> = yielded.iter().map(|(k, _)| k.clone()).collect();
+        assert_eq!(actual_keys, expected_keys);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// A high-cardinality workload — tens of thousands of distinct keys —
+    /// must flush and compact without errors. Pre-multi-level the L0→L1
+    /// compaction output's index would overflow the single 1 MB index
+    /// budget at this cardinality and compaction silently failed. The
+    /// existing stress tests miss this because they hammer 30–50 keys
+    /// repeatedly — after dedup, merged outputs are tiny.
     #[test]
     fn compaction_handles_high_cardinality_distinct_keys() {
         const SMALL_MEMTABLE: usize = 32 * 1024;
-        const NUM_KEYS: u64 = 4_000;
+        const NUM_KEYS: u64 = 50_000;
         const VALUE_SIZE: usize = 256;
 
         let dir = tmp_dir();
@@ -759,8 +864,10 @@ mod tests {
         }
 
         // Give the flusher + compactor time to drain. Compactions cascade,
-        // so this must be long enough for at least one L0→L1 pass.
-        std::thread::sleep(Duration::from_secs(5));
+        // so this must be long enough for at least one L0→L1 pass. 50 k
+        // keys × 256 B against a 32 KB memtable means several hundred
+        // flushes plus the cascading L0→L1, so we allow generous slack.
+        std::thread::sleep(Duration::from_secs(15));
 
         let version = engine.current_version();
         let l0 = version.files_at_level(0).len();

--- a/src/sstable/DESIGN.md
+++ b/src/sstable/DESIGN.md
@@ -46,23 +46,33 @@ estimated 10,000 keys per SSTable. Under these parameters the bitmap is
 11,982 bytes plus a 44-byte crate header, totalling approximately 12 KB per
 SSTable.
 
-### Index Block
+### Index Region (two-level)
 
-The index block has the same binary format as a data block (see below), but
-its entries map a block's first `user_key` to that block's byte offset in the
-file. Each index entry is:
+The index occupies two block tiers, both using the same binary format as a
+data block:
 
-- **Key**: the first `user_key` of the data block (with `seq_num = 0`).
-- **Value**: the data block's starting byte offset as a big-endian `u64` (8 bytes),
-  stored as a `Record::Put`.
+1. **L1 (leaf) index blocks** — each maps the first `user_key` of a data
+   block to that data block's byte offset (big-endian `u64`, stored as a
+   `Record::Put`). One L1 block covers a contiguous run of data blocks.
+   Target size `L1_INDEX_TARGET_BLOCK_SIZE = 64 KB` ≈ 1,300 data-block
+   pointers ≈ 5 MB of data per L1 block.
+2. **Top index block** — one entry per L1 block, mapping the first key of
+   each L1 region to that L1 block's byte offset. Target size
+   `TOP_INDEX_TARGET_BLOCK_SIZE = 1 MB`. A 64 MB SSTable produces ~16 L1
+   pointers (well under 1 KB); a 100 GB SSTable would produce ~1.2 MB.
 
-The index block uses a larger byte budget than data blocks
-(`INDEX_TARGET_BLOCK_SIZE = 1 MB` vs `TARGET_BLOCK_SIZE = 4 KB`) because it
-must hold one entry per data block in the entire SSTable. At ~50 bytes per
-index entry, 1 MB holds ~20,000 entries — addressing roughly 80 MB of data,
-which covers the compaction-output cap with headroom. The block format itself
-is unchanged; only the target size differs. If the index ever exceeds 1 MB,
-the writer returns an error and multi-level indexing becomes necessary.
+On-disk order is `L1 Block 0 | L1 Block 1 | … | L1 Block M | Top Index`,
+and the footer's index-offset field points at the **top index block**. The
+reader loads the top index eagerly on `open` and reads individual L1 blocks
+on demand during `search`.
+
+Both index entries store offsets as `Record::Put(u64_be)`. The block format
+itself is unchanged from data blocks — we lean entirely on
+`BlockBuilder::with_target_size` to tune each tier independently.
+
+If the top index itself overflows `TOP_INDEX_TARGET_BLOCK_SIZE` (only
+possible for SSTables larger than ~80 GB at current sizing), the writer
+returns an error and a third index level would be required.
 
 ### Footer (24 bytes)
 

--- a/src/sstable/reader.rs
+++ b/src/sstable/reader.rs
@@ -26,15 +26,21 @@ pub enum ReaderError {
 
 /// Provides point-lookup access to an on-disk SSTable file.
 ///
-/// On `open`, the footer is validated (magic number check) and the index
-/// block is loaded into memory. Subsequent `search` calls use the index to
-/// locate candidate data blocks, reading at most two blocks from disk to
-/// find the newest version of a key.
+/// On `open`, the footer is validated (magic number check) and the top
+/// index block is loaded into memory. Subsequent `search` calls navigate a
+/// two-level index: top → L1 (loaded on demand from disk) → data block.
+/// The MVCC-aware "predecessor + first-equal" candidate selection happens
+/// at both index levels so a key whose newest version sits at the tail of
+/// a preceding block is still found.
 pub struct SsTableReader {
     file: File,
-    index_block: Block,
-    /// Byte offset where the meta block begins (i.e. where data blocks end)
+    top_index: Block,
+    /// Byte offset where the meta block begins (i.e. where data blocks end).
+    /// Used as the implicit end of the last data block in an L1 region.
     meta_offset: u64,
+    /// Byte offset of the top index block. Used as the implicit end of the
+    /// last L1 block.
+    top_index_offset: u64,
     bloom: Bloom<String>,
 }
 
@@ -68,7 +74,7 @@ impl SsTableReader {
             u64::from_be_bytes(footer_buf[0..meta_end].try_into().map_err(|_| {
                 ReaderError::CorruptData("Failed to parse meta offset from footer".to_string())
             })?);
-        let index_offset =
+        let top_index_offset =
             u64::from_be_bytes(footer_buf[meta_end..index_end].try_into().map_err(|_| {
                 ReaderError::CorruptData("Failed to parse index offset from footer".to_string())
             })?);
@@ -81,129 +87,175 @@ impl SsTableReader {
             return Err(ReaderError::InvalidMagicNumber(magic));
         }
 
-        // 2. Read and deserialize the Meta Block (bloom filter)
-        let meta_size = index_offset - meta_offset;
+        // 2. Read and decode the Top Index Block. L1 blocks are read lazily
+        //    in `search`, not eagerly here. We do this *before* the bloom
+        //    so we can derive the meta block's exact size from the first
+        //    L1 block offset (the bloom payload has no length prefix; its
+        //    end is "wherever the first L1 block begins").
+        let top_index_size = file_len - (FOOTER_SIZE as u64) - top_index_offset;
+        file.seek(SeekFrom::Start(top_index_offset))?;
+        let mut top_index_data = vec![0u8; top_index_size as usize];
+        file.read_exact(&mut top_index_data)?;
+        let top_index = Block::decode(top_index_data);
+
+        // 3. Read and deserialize the Meta Block (bloom filter). It lives in
+        //    [meta_offset, first_L1_offset). For SSTables with no data
+        //    blocks (and therefore no L1 blocks) the top index is empty and
+        //    the bloom runs up to top_index_offset.
+        let first_l1_offset = first_offset_in(&top_index)?.unwrap_or(top_index_offset);
+        let meta_size = first_l1_offset - meta_offset;
         file.seek(SeekFrom::Start(meta_offset))?;
         let mut meta_data = vec![0u8; meta_size as usize];
         file.read_exact(&mut meta_data)?;
-
         let bloom = Bloom::from_bytes(meta_data)
             .map_err(|e| ReaderError::CorruptData(format!("Invalid bloom filter: {}", e)))?;
 
-        // 3. Read and decode the Index Block
-        let index_size = file_len - (FOOTER_SIZE as u64) - index_offset;
-        file.seek(SeekFrom::Start(index_offset))?;
-        let mut index_data = vec![0u8; index_size as usize];
-        file.read_exact(&mut index_data)?;
-
-        let index_block = Block::decode(index_data);
-
         Ok(Self {
             file,
-            index_block,
+            top_index,
             meta_offset,
+            top_index_offset,
             bloom,
         })
     }
 
     /// Searches for a specific user key in the SSTable.
-    /// Returns Ok(None) if the key does not exist in this file.
+    /// Returns `Ok(None)` if the key does not exist in this file.
+    ///
+    /// Walks the two-level index: top → up-to-2 candidate L1 blocks
+    /// (read from disk) → up-to-2 candidate data blocks per L1 (also from
+    /// disk). The predecessor + first-equal candidate-selection preserves
+    /// MVCC: a key whose newest version sits at the tail of a preceding
+    /// block is still found.
     pub fn search(
         &mut self,
         target_key: &str,
     ) -> Result<Option<(InternalKey, Record)>, ReaderError> {
-        // Fast path: if the bloom filter says the key is absent, skip disk reads
         if !self.bloom.check(&target_key.to_string()) {
             return Ok(None);
         }
 
-        let num_offsets = self.index_block.get_num_offsets()?;
-
-        if num_offsets == 0 {
+        // Top-level: find at-most-2 candidate L1 block ranges.
+        let l1_candidates =
+            find_candidates(&self.top_index, target_key, self.top_index_offset)?;
+        if l1_candidates.is_empty() {
             return Ok(None);
         }
 
-        let mut last_less_than = None;
-        let mut first_equal = None;
+        for (l1_start, l1_end) in l1_candidates {
+            // Load the L1 block from disk.
+            let l1_size = (l1_end - l1_start) as usize;
+            self.file.seek(SeekFrom::Start(l1_start))?;
+            let mut l1_data = vec![0u8; l1_size];
+            self.file.read_exact(&mut l1_data)?;
+            let l1_block = Block::decode(l1_data);
 
-        // 1. Scan the index to find the candidate blocks
-        for i in 0..num_offsets {
-            let entry_offset = self.index_block.get_offset(i, num_offsets)?;
-            let (key, record) = self.index_block.decode_entry(entry_offset)?;
+            // Within this L1 block, find at-most-2 candidate data block
+            // ranges. The data region ends at meta_offset.
+            let data_candidates = find_candidates(&l1_block, target_key, self.meta_offset)?;
 
-            let block_start = match record {
-                Record::Put(val) => u64::from_be_bytes(val.try_into().map_err(|_| {
-                    ReaderError::CorruptData("Index block pointer is not 8 bytes".to_string())
-                })?),
-                Record::Delete => {
-                    return Err(ReaderError::CorruptData(
-                        "Index block contains Delete record".to_string(),
-                    ));
+            for (data_start, data_end) in data_candidates {
+                let data_size = (data_end - data_start) as usize;
+                self.file.seek(SeekFrom::Start(data_start))?;
+                let mut data_block_bytes = vec![0u8; data_size];
+                self.file.read_exact(&mut data_block_bytes)?;
+                let data_block = Block::decode(data_block_bytes);
+
+                // Block::search returns the newest version (highest seq)
+                // present for `target_key` in that block.
+                if let Some(result) = data_block.search(target_key)? {
+                    return Ok(Some(result));
                 }
-            };
-
-            let next_block_offset = if i + 1 < num_offsets {
-                let next_entry_offset = self.index_block.get_offset(i + 1, num_offsets)?;
-                let (_, next_record) = self.index_block.decode_entry(next_entry_offset)?;
-
-                match next_record {
-                    Record::Put(val) => u64::from_be_bytes(val.try_into().map_err(|_| {
-                        ReaderError::CorruptData("Next index pointer is not 8 bytes".to_string())
-                    })?),
-                    Record::Delete => {
-                        return Err(ReaderError::CorruptData(
-                            "Next index contains Delete".to_string(),
-                        ));
-                    }
-                }
-            } else {
-                self.meta_offset
-            };
-
-            // Route to the correct candidate blocks
-            if key.user_key.as_str() < target_key {
-                last_less_than = Some((block_start, next_block_offset));
-            } else if key.user_key.as_str() == target_key {
-                if first_equal.is_none() {
-                    first_equal = Some((block_start, next_block_offset));
-                }
-                // Once we find the first block starting with the target, we don't need to look
-                // further. Subsequent blocks will only contain older versions.
-                break;
-            } else {
-                // key.user_key > target_key
-                break;
-            }
-        }
-
-        // Gather our candidates (at most 2 blocks)
-        let mut candidate_blocks = Vec::new();
-        if let Some(block) = last_less_than {
-            candidate_blocks.push(block);
-        }
-        if let Some(block) = first_equal {
-            candidate_blocks.push(block);
-        }
-
-        // 2. Read the candidate blocks from disk and search them in order
-        for (start_offset, next_offset) in candidate_blocks {
-            let block_size = next_offset - start_offset;
-
-            self.file.seek(SeekFrom::Start(start_offset))?;
-            let mut block_data = vec![0u8; block_size as usize];
-            self.file.read_exact(&mut block_data)?;
-
-            let data_block = Block::decode(block_data);
-
-            // If we find the key in the first candidate (which contains the highest seq numbers),
-            // we return it immediately and skip reading the second block.
-            if let Some(result) = data_block.search(target_key)? {
-                return Ok(Some(result));
             }
         }
 
         Ok(None)
     }
+}
+
+/// Decode the `u64` offset stored as a `Record::Put` payload in an index entry.
+fn decode_offset(record: Record) -> Result<u64, ReaderError> {
+    match record {
+        Record::Put(val) => {
+            let arr: [u8; 8] = val.try_into().map_err(|_| {
+                ReaderError::CorruptData("Index pointer is not 8 bytes".to_string())
+            })?;
+            Ok(u64::from_be_bytes(arr))
+        }
+        Record::Delete => Err(ReaderError::CorruptData(
+            "Index block contains Delete record".to_string(),
+        )),
+    }
+}
+
+/// Read the offset stored in the first entry of `index`, or `None` if empty.
+fn first_offset_in(index: &Block) -> Result<Option<u64>, ReaderError> {
+    let n = index.get_num_offsets()?;
+    if n == 0 {
+        return Ok(None);
+    }
+    let entry_offset = index.get_offset(0, n)?;
+    let (_, record) = index.decode_entry(entry_offset)?;
+    decode_offset(record).map(Some)
+}
+
+/// MVCC-aware candidate selection over an index block.
+///
+/// Returns at most two `(start, end)` byte ranges in order: the predecessor
+/// (last entry whose first key < target) and the first entry whose first
+/// key == target. `region_end` is the byte offset where the indexed region
+/// ends (used to compute the end of the last entry). The same routine is
+/// used at the top index level (region_end = top_index_offset) and at the
+/// L1 level (region_end = meta_offset).
+///
+/// The predecessor is included because the newest version of `target` could
+/// be at the tail of the block that opens with a key < target.
+fn find_candidates(
+    index: &Block,
+    target_key: &str,
+    region_end: u64,
+) -> Result<Vec<(u64, u64)>, ReaderError> {
+    let n = index.get_num_offsets()?;
+    if n == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut last_less_than: Option<(u64, u64)> = None;
+    let mut first_equal: Option<(u64, u64)> = None;
+
+    for i in 0..n {
+        let entry_offset = index.get_offset(i, n)?;
+        let (key, record) = index.decode_entry(entry_offset)?;
+        let block_start = decode_offset(record)?;
+
+        let block_end = if i + 1 < n {
+            let next_entry_offset = index.get_offset(i + 1, n)?;
+            let (_, next_record) = index.decode_entry(next_entry_offset)?;
+            decode_offset(next_record)?
+        } else {
+            region_end
+        };
+
+        if key.user_key.as_str() < target_key {
+            last_less_than = Some((block_start, block_end));
+        } else if key.user_key.as_str() == target_key {
+            if first_equal.is_none() {
+                first_equal = Some((block_start, block_end));
+            }
+            break;
+        } else {
+            break;
+        }
+    }
+
+    let mut candidates = Vec::new();
+    if let Some(c) = last_less_than {
+        candidates.push(c);
+    }
+    if let Some(c) = first_equal {
+        candidates.push(c);
+    }
+    Ok(candidates)
 }
 
 #[cfg(test)]

--- a/src/sstable/writer.rs
+++ b/src/sstable/writer.rs
@@ -28,13 +28,18 @@ const BLOOM_FP_RATE: f64 = 0.01;
 /// raises the false-positive rate.
 const BLOOM_ESTIMATED_ITEMS: u32 = 10_000;
 
-/// Target byte budget for the index block. The index needs one entry per
-/// data block in the whole SSTable; at 4 KB data blocks and ~50-byte index
-/// entries, 1 MB holds ~20k entries → addresses ~80 MB of data, which
-/// comfortably covers the compaction-output cap. Pay the resident-memory
-/// cost (one of these per open SSTable) in exchange for keeping a
-/// single-level index.
-const INDEX_TARGET_BLOCK_SIZE: usize = 1024 * 1024;
+/// Target byte budget for an L1 (leaf) index block. Each L1 block maps a
+/// contiguous run of data blocks to their byte offsets. At ~51 bytes per
+/// entry, 64 KB holds ~1,300 data-block pointers (≈ 5 MB of data per L1
+/// block), which keeps a single L1 read cheap on the read path while still
+/// allowing the top index to stay tiny.
+const L1_INDEX_TARGET_BLOCK_SIZE: usize = 64 * 1024;
+
+/// Target byte budget for the top index block. The top index has one entry
+/// per L1 block; for typical 64 MB SSTables this is ~16 entries, well under
+/// 1 KB. Sized at 1 MB so multi-GB SSTables can still address all their L1
+/// blocks from a single top block (~80 GB at this size).
+const TOP_INDEX_TARGET_BLOCK_SIZE: usize = 1024 * 1024;
 
 /// Writes a sorted stream of key-record pairs to an on-disk SSTable file.
 ///
@@ -146,30 +151,9 @@ impl SsTableBuilder {
         self.file.write_all(&meta_data)?;
         self.current_offset += meta_data.len() as u64;
 
-        // Build the Index Block — uses a larger target than data blocks
-        // since one index entry is required per data block in the whole file.
-        let mut index_block = BlockBuilder::with_target_size(INDEX_TARGET_BLOCK_SIZE);
-        for (first_key, offset) in &self.block_index {
-            let index_key = InternalKey {
-                user_key: first_key.clone(),
-                seq_num: 0, // Dummy seq_num for index entries
-            };
-            let index_record = Record::Put(offset.to_be_bytes().to_vec());
-
-            let added = index_block.add(&index_key, &index_record);
-            if !added {
-                return Err(WriterError::InvalidData(
-                    "Index block exceeded INDEX_TARGET_BLOCK_SIZE. Multi-level index implementation required.".to_string()
-                ));
-            }
-        }
-
-        // Write the Index Block
-        let index_data = index_block.build();
-        let index_offset = self.current_offset;
-
-        self.file.write_all(&index_data)?;
-        self.current_offset += index_data.len() as u64;
+        // Write the two-level index (L1 blocks then top index).
+        // `top_index_offset` is what gets recorded in the footer.
+        let top_index_offset = self.write_two_level_index()?;
 
         // Write a fixed-size Footer (24 bytes)
         let mut footer = [0u8; FOOTER_SIZE];
@@ -178,7 +162,7 @@ impl SsTableBuilder {
         let magic_end = index_end + MAGIC_SIZE;
 
         footer[0..meta_end].copy_from_slice(&meta_offset.to_be_bytes());
-        footer[meta_end..index_end].copy_from_slice(&index_offset.to_be_bytes());
+        footer[meta_end..index_end].copy_from_slice(&top_index_offset.to_be_bytes());
         footer[index_end..magic_end].copy_from_slice(&MAGIC_NUMBER.to_be_bytes());
 
         self.file.write_all(&footer)?;
@@ -248,34 +232,16 @@ impl SsTableBuilder {
         self.file.write_all(&meta_data)?;
         self.current_offset += meta_data.len() as u64;
 
-        // Build and write the Index Block (see build_from_iterator for the
-        // size rationale).
-        let mut index_block = BlockBuilder::with_target_size(INDEX_TARGET_BLOCK_SIZE);
-        for (first_key, offset) in &self.block_index {
-            let index_key = InternalKey {
-                user_key: first_key.clone(),
-                seq_num: 0,
-            };
-            let index_record = Record::Put(offset.to_be_bytes().to_vec());
-            if !index_block.add(&index_key, &index_record) {
-                return Err(WriterError::InvalidData(
-                    "Index block exceeded INDEX_TARGET_BLOCK_SIZE; multi-level index required"
-                        .to_string(),
-                ));
-            }
-        }
+        // Write the two-level index (L1 blocks then top index).
+        let top_index_offset = self.write_two_level_index()?;
 
-        let index_data = index_block.build();
-        let index_offset = self.current_offset;
-        self.file.write_all(&index_data)?;
-
-        // Write the Footer: [meta_offset | index_offset | magic]
+        // Write the Footer: [meta_offset | top_index_offset | magic]
         let mut footer = [0u8; FOOTER_SIZE];
         let meta_end = META_OFFSET_SIZE;
         let index_end = meta_end + INDEX_OFFSET_SIZE;
         let magic_end = index_end + MAGIC_SIZE;
         footer[0..meta_end].copy_from_slice(&meta_offset.to_be_bytes());
-        footer[meta_end..index_end].copy_from_slice(&index_offset.to_be_bytes());
+        footer[meta_end..index_end].copy_from_slice(&top_index_offset.to_be_bytes());
         footer[index_end..magic_end].copy_from_slice(&MAGIC_NUMBER.to_be_bytes());
         self.file.write_all(&footer)?;
         self.file.sync_all()?;
@@ -284,6 +250,101 @@ impl SsTableBuilder {
             (Some(lo), Some(hi)) => Some((lo, hi, self.max_seq_num)),
             _ => None,
         })
+    }
+
+    /// Build and write the two-level index for this SSTable.
+    ///
+    /// Walks `self.block_index` (the in-memory list of `(first_key,
+    /// data_block_offset)` recorded by `finish_current_block`), packs the
+    /// entries into L1 index blocks of `L1_INDEX_TARGET_BLOCK_SIZE`, writes
+    /// each L1 block to disk, then builds and writes the top index whose
+    /// entries point at the L1 blocks. Returns the byte offset of the top
+    /// index block, which the caller writes into the footer.
+    ///
+    /// The two-level structure removes the single-block index ceiling that
+    /// would otherwise cap SSTables at ~1 MB of index entries.
+    fn write_two_level_index(&mut self) -> Result<u64, WriterError> {
+        let mut l1_index: Vec<(String, u64)> = Vec::new();
+        let mut current_l1 = BlockBuilder::with_target_size(L1_INDEX_TARGET_BLOCK_SIZE);
+        let mut current_l1_first_key: Option<String> = None;
+
+        for (first_key, data_block_offset) in &self.block_index {
+            let entry_key = InternalKey {
+                user_key: first_key.clone(),
+                seq_num: 0, // Dummy seq for index entries.
+            };
+            let entry_val = Record::Put(data_block_offset.to_be_bytes().to_vec());
+
+            if !current_l1.add(&entry_key, &entry_val) {
+                // Current L1 is full. Flush it, then start a fresh L1 that
+                // opens with the rejected entry.
+                let full_l1 = std::mem::replace(
+                    &mut current_l1,
+                    BlockBuilder::with_target_size(L1_INDEX_TARGET_BLOCK_SIZE),
+                );
+                let l1_data = full_l1.build();
+                let l1_offset = self.current_offset;
+                self.file.write_all(&l1_data)?;
+                self.current_offset += l1_data.len() as u64;
+                l1_index.push((
+                    current_l1_first_key
+                        .take()
+                        .expect("L1 builder accepted entries; first key must be set"),
+                    l1_offset,
+                ));
+
+                // The just-rejected entry becomes the first of the new L1
+                // block. A single index entry should always fit in a fresh
+                // L1 block; if not, the L1 target is misconfigured.
+                if !current_l1.add(&entry_key, &entry_val) {
+                    return Err(WriterError::InvalidData(
+                        "A single index entry exceeds L1_INDEX_TARGET_BLOCK_SIZE"
+                            .to_string(),
+                    ));
+                }
+                current_l1_first_key = Some(first_key.clone());
+            } else if current_l1_first_key.is_none() {
+                current_l1_first_key = Some(first_key.clone());
+            }
+        }
+
+        // Flush the trailing partial L1 block (if any entries are buffered).
+        if !current_l1.is_empty() {
+            let l1_data = current_l1.build();
+            let l1_offset = self.current_offset;
+            self.file.write_all(&l1_data)?;
+            self.current_offset += l1_data.len() as u64;
+            l1_index.push((
+                current_l1_first_key
+                    .take()
+                    .expect("non-empty L1 block has a first key"),
+                l1_offset,
+            ));
+        }
+
+        // Build and write the top index. Each entry maps the first key of
+        // an L1 block to that block's offset.
+        let mut top = BlockBuilder::with_target_size(TOP_INDEX_TARGET_BLOCK_SIZE);
+        for (first_key, l1_offset) in &l1_index {
+            let key = InternalKey {
+                user_key: first_key.clone(),
+                seq_num: 0,
+            };
+            let val = Record::Put(l1_offset.to_be_bytes().to_vec());
+            if !top.add(&key, &val) {
+                return Err(WriterError::InvalidData(
+                    "Top index exceeded TOP_INDEX_TARGET_BLOCK_SIZE; \
+                     a third level is needed for SSTables this large"
+                        .to_string(),
+                ));
+            }
+        }
+        let top_data = top.build();
+        let top_offset = self.current_offset;
+        self.file.write_all(&top_data)?;
+        self.current_offset += top_data.len() as u64;
+
+        Ok(top_offset)
     }
 
     /// Helper to write the current block to disk and record its location in the index.
@@ -469,6 +530,14 @@ mod tests {
         );
     }
 
+    /// Decode an index entry's `Record::Put` value as a u64 offset.
+    fn decode_offset_record(record: Record) -> u64 {
+        match record {
+            Record::Put(val) => u64::from_be_bytes(val.try_into().unwrap()),
+            Record::Delete => panic!("Index block should not contain deletes"),
+        }
+    }
+
     #[test]
     fn test_builder_single_block() {
         let file = TempFileGuard::new("single_block_test.sst");
@@ -484,48 +553,49 @@ mod tests {
         let iter = Box::new(MockIterator::new(entries));
         builder.build_from_iterator(iter).unwrap();
 
-        // --- Verification ---
+        // --- Verification: navigate the two-level index ---
         let data = fs::read(&file.path).unwrap();
         let len = data.len();
 
-        let (meta_offset, index_offset) = parse_footer(&data);
+        let (meta_offset, top_index_offset) = parse_footer(&data);
 
-        // 1. Verify Index Block
-        let index_data = data[index_offset..len - FOOTER_SIZE].to_vec();
-        let index_block = Block::decode(index_data);
-
+        // 1. Top index: exactly 1 L1 block.
+        let top_data = data[top_index_offset..len - FOOTER_SIZE].to_vec();
+        let top_index = Block::decode(top_data);
         assert_eq!(
-            index_block.get_num_offsets().unwrap(),
+            top_index.get_num_offsets().unwrap(),
             1,
-            "There should be exactly 1 data block indexed"
+            "Top index should contain exactly 1 L1 pointer"
         );
-        let offset_index_0 = index_block.get_offset(0, 1).unwrap();
-        let (first_key_entry, pointer_record) = index_block.decode_entry(offset_index_0).unwrap();
+        let (top_key, top_record) = top_index
+            .decode_entry(top_index.get_offset(0, 1).unwrap())
+            .unwrap();
+        assert_eq!(top_key.user_key, "apple", "Top index opens with apple");
+        let l1_start = decode_offset_record(top_record) as usize;
 
+        // 2. L1 block (between meta block and top index, opens at l1_start).
+        let l1_end = top_index_offset;
+        let l1_data = data[l1_start..l1_end].to_vec();
+        let l1_block = Block::decode(l1_data);
         assert_eq!(
-            first_key_entry.user_key, "apple",
-            "Index should track the first key of the block"
+            l1_block.get_num_offsets().unwrap(),
+            1,
+            "L1 should contain exactly 1 data-block pointer"
         );
-
-        // Extract the physical offset to the data block
-        let data_block_offset = match pointer_record {
-            Record::Put(val) => u64::from_be_bytes(val.try_into().unwrap()) as usize,
-            Record::Delete => panic!("Index block should not contain deletes"),
-        };
+        let (l1_key, l1_record) = l1_block
+            .decode_entry(l1_block.get_offset(0, 1).unwrap())
+            .unwrap();
+        assert_eq!(l1_key.user_key, "apple", "L1 entry opens with apple");
         assert_eq!(
-            data_block_offset, 0,
-            "The first data block should start at byte 0"
+            decode_offset_record(l1_record),
+            0,
+            "First data block should start at byte 0"
         );
 
-        // 2. Verify Data Block (data blocks end where the meta block begins)
+        // 3. Data block (data blocks end where the meta block begins).
         let data_block_bytes = data[0..meta_offset].to_vec();
         let data_block = Block::decode(data_block_bytes);
-
-        assert_eq!(
-            data_block.get_num_offsets().unwrap(),
-            3,
-            "Data block should contain 3 entries"
-        );
+        assert_eq!(data_block.get_num_offsets().unwrap(), 3);
 
         let (cherry_k, cherry_r) = data_block.search("cherry").unwrap().unwrap();
         assert_eq!(cherry_k.seq_num, 1);
@@ -549,57 +619,72 @@ mod tests {
         let iter = Box::new(MockIterator::new(entries));
         builder.build_from_iterator(iter).unwrap();
 
-        // --- Verification ---
+        // --- Verification: walk top → L1 → data ---
         let data = fs::read(&file.path).unwrap();
         let len = data.len();
 
-        let (_meta_offset, index_offset) = parse_footer(&data);
+        let (meta_offset, top_index_offset) = parse_footer(&data);
 
-        // 1. Verify Index Block has multiple pointers
-        let index_data = data[index_offset..len - FOOTER_SIZE].to_vec();
-        let index_block = Block::decode(index_data);
+        // Top index → collect (l1_start, l1_end) ranges.
+        let top_data = data[top_index_offset..len - FOOTER_SIZE].to_vec();
+        let top_index = Block::decode(top_data);
+        let n_l1 = top_index.get_num_offsets().unwrap();
+        assert!(n_l1 >= 1);
+        let mut l1_ranges: Vec<(usize, usize)> = Vec::with_capacity(n_l1);
+        for i in 0..n_l1 {
+            let entry_off = top_index.get_offset(i, n_l1).unwrap();
+            let (_, rec) = top_index.decode_entry(entry_off).unwrap();
+            let start = decode_offset_record(rec) as usize;
+            let end = if i + 1 < n_l1 {
+                let next_off = top_index.get_offset(i + 1, n_l1).unwrap();
+                let (_, next_rec) = top_index.decode_entry(next_off).unwrap();
+                decode_offset_record(next_rec) as usize
+            } else {
+                top_index_offset
+            };
+            l1_ranges.push((start, end));
+        }
 
-        let num_data_blocks = index_block.get_num_offsets().unwrap();
+        // Across all L1 blocks → collect the flat list of data-block ranges.
+        let mut data_block_starts: Vec<usize> = Vec::new();
+        let mut data_block_first_keys: Vec<String> = Vec::new();
+        for (l1_start, l1_end) in &l1_ranges {
+            let l1_data = data[*l1_start..*l1_end].to_vec();
+            let l1_block = Block::decode(l1_data);
+            let n = l1_block.get_num_offsets().unwrap();
+            for j in 0..n {
+                let entry_off = l1_block.get_offset(j, n).unwrap();
+                let (idx_key, idx_rec) = l1_block.decode_entry(entry_off).unwrap();
+                data_block_starts.push(decode_offset_record(idx_rec) as usize);
+                data_block_first_keys.push(idx_key.user_key);
+            }
+        }
+
         assert!(
-            num_data_blocks > 1,
+            data_block_starts.len() > 1,
             "Builder should have created multiple data blocks"
         );
 
-        // 2. Walk through the index and verify EVERY Data Block
-        for i in 0..num_data_blocks {
-            let idx_entry_offset = index_block.get_offset(i, num_data_blocks).unwrap();
-            let (idx_key, pointer_record) = index_block.decode_entry(idx_entry_offset).unwrap();
-
-            let block_start = match pointer_record {
-                Record::Put(val) => u64::from_be_bytes(val.try_into().unwrap()) as usize,
-                Record::Delete => panic!("Index contains a Delete"),
-            };
-
-            // The block ends where the next block begins, or where the index block begins
-            let block_end = if i + 1 < num_data_blocks {
-                let next_idx_entry_offset = index_block.get_offset(i + 1, num_data_blocks).unwrap();
-                let (_, next_pointer_record) =
-                    index_block.decode_entry(next_idx_entry_offset).unwrap();
-                match next_pointer_record {
-                    Record::Put(val) => u64::from_be_bytes(val.try_into().unwrap()) as usize,
-                    _ => unreachable!(),
-                }
+        // Walk every data block, confirm its first key matches what the
+        // index claims.
+        for i in 0..data_block_starts.len() {
+            let block_start = data_block_starts[i];
+            let block_end = if i + 1 < data_block_starts.len() {
+                data_block_starts[i + 1]
             } else {
-                index_offset
+                meta_offset
             };
 
             let data_block_bytes = data[block_start..block_end].to_vec();
             let data_block = Block::decode(data_block_bytes);
-
-            // Ensure the data block is valid and its first key matches what the index block claims!
             let first_key_offset = data_block
                 .get_offset(0, data_block.get_num_offsets().unwrap())
                 .unwrap();
             let (actual_first_key, _) = data_block.decode_entry(first_key_offset).unwrap();
 
             assert_eq!(
-                idx_key.user_key, actual_first_key.user_key,
-                "Index block key does not match actual first key of data block {}",
+                data_block_first_keys[i], actual_first_key.user_key,
+                "Index key does not match actual first key of data block {}",
                 i
             );
         }
@@ -700,5 +785,61 @@ mod tests {
             "File size ({} bytes) is unusually large, possible runaway allocation",
             file_size
         );
+    }
+
+    /// An SSTable with enough distinct keys to force the L1 index to spill
+    /// across multiple blocks must still round-trip cleanly through
+    /// `SsTableReader::search`. Pre-multi-level this would fail with
+    /// "Index block exceeded INDEX_TARGET_BLOCK_SIZE".
+    #[test]
+    fn sstable_round_trip_multi_l1_index() {
+        use crate::sstable::reader::SsTableReader;
+
+        const NUM_KEYS: u64 = 30_000;
+        const VALUE_SIZE: usize = 256;
+
+        let file = TempFileGuard::new("multi_l1_round_trip.sst");
+        let mut builder = SsTableBuilder::new(file.path_str()).unwrap();
+
+        let entries: Vec<(String, Record, u64)> = (0..NUM_KEYS)
+            .map(|i| {
+                let key = format!("key_{:020}", i);
+                let val = vec![(i % 256) as u8; VALUE_SIZE];
+                (key, Record::Put(val), NUM_KEYS - i)
+            })
+            .collect();
+
+        builder
+            .build_from_iterator(Box::new(MockIterator::new(entries)))
+            .unwrap();
+
+        // Verify structurally: walk the top index and confirm there's more
+        // than one L1 block (which is what proves the multi-level path
+        // is being exercised).
+        let raw = fs::read(&file.path).unwrap();
+        let (_meta_offset, top_index_offset) = parse_footer(&raw);
+        let top_data = raw[top_index_offset..raw.len() - FOOTER_SIZE].to_vec();
+        let top_index = Block::decode(top_data);
+        let n_l1 = top_index.get_num_offsets().unwrap();
+        assert!(
+            n_l1 > 1,
+            "Expected multiple L1 index blocks for {} keys, got {}",
+            NUM_KEYS,
+            n_l1,
+        );
+
+        // Reads succeed across the whole key range (first, middle, last).
+        let mut reader = SsTableReader::open(file.path_str()).unwrap();
+        for sample_i in [0u64, NUM_KEYS / 2, NUM_KEYS - 1] {
+            let key = format!("key_{:020}", sample_i);
+            let got = reader.search(&key).unwrap();
+            let (k, r) = got.unwrap_or_else(|| panic!("missing {}", key));
+            assert_eq!(k.user_key, key);
+            assert_eq!(k.seq_num, NUM_KEYS - sample_i);
+            assert!(matches!(r, Record::Put(v) if v.len() == VALUE_SIZE));
+        }
+
+        // A key absent from the SSTable returns None (bloom + structural).
+        assert!(reader.search("key_99999999999999999999").unwrap().is_none());
     }
 }

--- a/workloads/README.md
+++ b/workloads/README.md
@@ -28,13 +28,9 @@ TOML preset and edit it. Run-time knobs (`--dir`, `--duration`, `--seed`,
 `--cooldown`, `--memtable-size`) are always supplied via CLI; the TOML
 describes the *workload*, not the *run*.
 
-> **Note on current engine limits.** The SSTable writer uses a single-level
-> 1 MB index block (see `src/sstable/DESIGN.md`). At the full 1M × 1KB
-> defaults, the L0→L1 compaction output's index exceeds 1 MB and the
-> compaction fails. Until copperdb grows a multi-level index, smoke-test the
-> presets with smaller overrides — e.g.
-> `--keys 5000 --value-size 256` — or use smaller per-value sizes
-> (`--value-size 64`) at the full key count.
+The SSTable writer uses a two-level index (see `src/sstable/DESIGN.md`), so
+the TOML defaults run as written. Smaller overrides remain useful for fast
+smoke tests during development.
 
 Reference: B. F. Cooper et al., *Benchmarking Cloud Serving Systems with
 YCSB* (SoCC '10). Our numbers aren't directly comparable to the paper's


### PR DESCRIPTION
The Option B fix raised the single index block to 1 MB, which still wasn't enough for the bench's actual target workloads. At 1 KB values × 64 MB SSTables, the index needs ~1.02 MB — just over the ceiling. Every TOML preset under workloads/ had a "use --keys 5000 --value-size 256 to dodge the index limit" caveat as a result.

Replace the single index block with a two-level structure:

  - L1 (leaf) index blocks at 64 KB target. Each maps a contiguous run of data blocks via (first_key, data_block_offset) entries — ~1,300 pointers per block, ~5 MB of data addressed per L1 block.
  - Top index block at 1 MB target. One entry per L1 block: (first_key_of_L1, L1_block_offset). A 64 MB SSTable produces ~16 pointers (well under 1 KB); a 100 GB SSTable would produce ~1.2 MB.

On-disk order: Data … | Meta (bloom) | L1 0 | L1 1 | … | L1 M | Top | Footer The footer's existing index-offset field now points at the top index — no format-field changes, only semantics.

Writer (src/sstable/writer.rs):
  Both build_from_iterator and finish_file now call a shared
  write_two_level_index helper. Constants renamed for clarity:
  INDEX_TARGET_BLOCK_SIZE → TOP_INDEX_TARGET_BLOCK_SIZE; added
  L1_INDEX_TARGET_BLOCK_SIZE = 64 KB.

Reader (src/sstable/reader.rs):
  open loads only the top index eagerly; derives the bloom's byte size
  from the first L1 offset (no length prefix needed). search runs a new
  find_candidates helper at both tiers — top index → at-most-2 L1 blocks,
  each L1 → at-most-2 data blocks — preserving the MVCC "predecessor +
  first-equal" invariant. Worst-case 6 disk reads per lookup; typical 2.

Iterator (src/compaction/mod.rs):
  SsTableIterator::open walks top → L1 to collect every data-block offset
  before iteration begins. KvIterator impl unchanged.

Tests:
  - sstable_round_trip_multi_l1_index (writer): 30 k entries × 256 B force multiple L1 blocks; reads succeed across the range.
  - sstable_iterator_walks_multi_l1 (compaction): same setup; iterator yields all entries in sorted order.
  - compaction_handles_high_cardinality_distinct_keys bumped 4 k → 50 k keys so it now drives multi-L1 compaction outputs end-to-end.
  - test_builder_single_block / test_builder_multiple_blocks updated to navigate the two-level on-disk layout.

Docs:
  - src/sstable/DESIGN.md gets a fresh "Index Region (two-level)" section.
  - workloads/README.md and src/bin/README.md drop the index-limit caveat; TOML presets now run at their actual 1 M × 1 KB defaults.

Verification: 148 tests pass (146 prior + 2 new multi-L1). YCSB-A at the unmodified TOML defaults runs cleanly with zero compaction errors — something the bench has never been able to do until now.