### PR TITLE
Add range-scan to the engine API

### DIFF
--- a/src/compaction/mod.rs
+++ b/src/compaction/mod.rs
@@ -51,8 +51,9 @@ pub enum CompactionError {
 // ---------------------------------------------------------------------------
 
 /// Reads an SSTable file block-by-block and yields every (key, record, seq_num)
-/// entry in on-disk (sorted) order. Used as one input stream to `MergingIterator`.
-struct SsTableIterator {
+/// entry in on-disk (sorted) order. Used as one input stream to `MergingIterator`
+/// — both by the compactor and by `LsmEngine::scan`.
+pub(crate) struct SsTableIterator {
     file: File,
     /// Byte ranges for each data block: (start_inclusive, end_exclusive).
     block_ranges: Vec<(u64, u64)>,
@@ -65,7 +66,7 @@ struct SsTableIterator {
 }
 
 impl SsTableIterator {
-    fn open(path: &Path) -> Result<Self, CompactionError> {
+    pub(crate) fn open(path: &Path) -> Result<Self, CompactionError> {
         let mut file = File::open(path)?;
         let file_len = file.metadata()?.len();
 
@@ -291,13 +292,14 @@ impl PartialOrd for HeapEntry {
 }
 
 /// Merges N sorted iterators into one sorted stream using a binary min-heap.
-struct MergingIterator {
+/// Used by the compactor and by `LsmEngine::scan`.
+pub(crate) struct MergingIterator {
     iterators: Vec<Box<dyn KvIterator>>,
     heap: BinaryHeap<HeapEntry>,
 }
 
 impl MergingIterator {
-    fn new(mut iterators: Vec<Box<dyn KvIterator>>) -> Self {
+    pub(crate) fn new(mut iterators: Vec<Box<dyn KvIterator>>) -> Self {
         let mut heap = BinaryHeap::with_capacity(iterators.len());
 
         for (idx, iter) in iterators.iter_mut().enumerate() {

--- a/src/core/storage.rs
+++ b/src/core/storage.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::ops::Bound;
 
 use async_trait::async_trait;
 
@@ -23,4 +24,15 @@ pub trait StorageEngine: Send + Sync {
     async fn put(&self, key: String, value: Vec<u8>) -> Result<(), EngineError>;
     async fn get(&self, key: String) -> Result<Option<Vec<u8>>, EngineError>;
     async fn delete(&self, key: String) -> Result<(), EngineError>;
+
+    /// Range scan over `[start, end)` (Bound flexibility on both ends),
+    /// returning up to `limit` live (key, value) pairs in ascending key order.
+    /// Tombstones suppress their key from the output; only the newest version
+    /// of each key is returned.
+    async fn scan(
+        &self,
+        start: Bound<String>,
+        end: Bound<String>,
+        limit: usize,
+    ) -> Result<Vec<(String, Vec<u8>)>, EngineError>;
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -16,6 +16,8 @@ use crate::sstable::reader::SsTableReader;
 
 use std::time::Duration;
 
+mod scan;
+
 #[cfg(test)]
 mod property_tests;
 #[cfg(test)]
@@ -335,6 +337,23 @@ impl EngineCore {
         Ok(())
     }
 
+    /// Range scan: returns up to `limit` live `(user_key, value)` pairs whose
+    /// keys fall in the range described by `start` and `end` (both `Bound`),
+    /// in ascending key order. Tombstones suppress their key from the output;
+    /// only the newest version of each key is returned.
+    ///
+    /// Snapshot semantics: the scan observes a consistent point-in-time view
+    /// of the engine. Concurrent writes that arrive after the call begins are
+    /// not reflected.
+    pub fn scan(
+        &self,
+        start: std::ops::Bound<&str>,
+        end: std::ops::Bound<&str>,
+        limit: usize,
+    ) -> io::Result<Vec<(String, Vec<u8>)>> {
+        scan::scan_impl(self, start, end, limit)
+    }
+
     /// Read-only snapshot of engine counters and live state. Used by the
     /// benchmark harness for diagnostic time-series output; cheap enough to
     /// call once per second.
@@ -498,6 +517,32 @@ impl StorageEngine for LsmHandle {
             .await
             .expect("spawn_blocking panicked")
             .map_err(EngineError::from)
+    }
+
+    async fn scan(
+        &self,
+        start: std::ops::Bound<String>,
+        end: std::ops::Bound<String>,
+        limit: usize,
+    ) -> Result<Vec<(String, Vec<u8>)>, EngineError> {
+        let engine = Arc::clone(&self.inner);
+        tokio::task::spawn_blocking(move || {
+            engine.scan(bound_as_ref(&start), bound_as_ref(&end), limit)
+        })
+        .await
+        .expect("spawn_blocking panicked")
+        .map_err(EngineError::from)
+    }
+}
+
+/// Convert `&Bound<String>` to `Bound<&str>` for the sync engine call. The
+/// async API takes owned `String`s because the future must be `'static`
+/// once spawned onto the blocking pool, but the sync API can borrow.
+fn bound_as_ref(b: &std::ops::Bound<String>) -> std::ops::Bound<&str> {
+    match b {
+        std::ops::Bound::Included(s) => std::ops::Bound::Included(s.as_str()),
+        std::ops::Bound::Excluded(s) => std::ops::Bound::Excluded(s.as_str()),
+        std::ops::Bound::Unbounded => std::ops::Bound::Unbounded,
     }
 }
 
@@ -1206,5 +1251,219 @@ mod tests {
         assert_eq!(stats.in_flight_compactions, 0);
         assert_eq!(stats.l0_file_count, 0);
         assert_eq!(stats.immutable_queue_depth, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Range-scan tests
+    //
+    // Each test covers one slice of `LsmEngine::scan`'s contract:
+    // empty / bounds / limit / tombstones / MVCC dedup / memtable+SSTable
+    // overlap / cross-level merging.
+    // -----------------------------------------------------------------------
+
+    use std::ops::Bound;
+
+    /// `scan` on a fresh engine returns nothing.
+    #[test]
+    fn scan_empty_engine_returns_empty() {
+        let dir = tmp_dir();
+        let engine = LsmEngine::open(&dir).unwrap();
+        let out = engine
+            .scan(Bound::Unbounded, Bound::Unbounded, 100)
+            .unwrap();
+        assert!(out.is_empty());
+    }
+
+    /// Inclusive/Excluded bounds + ascending order over keys present only in
+    /// the active memtable.
+    #[test]
+    fn scan_memtable_only_range_with_bounds() {
+        let dir = tmp_dir();
+        let engine = LsmEngine::open(&dir).unwrap();
+
+        // Load 10 keys: k00..k09 mapping to values 0..9.
+        for i in 0u32..10 {
+            engine
+                .put(format!("k{:02}", i), vec![i as u8])
+                .unwrap();
+        }
+
+        // [k03, k07) — Included start, Excluded end. Expect k03..k06.
+        let out = engine
+            .scan(Bound::Included("k03"), Bound::Excluded("k07"), 100)
+            .unwrap();
+        let keys: Vec<&str> = out.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(keys, vec!["k03", "k04", "k05", "k06"]);
+
+        // Values come back intact.
+        assert_eq!(out[0].1, vec![3u8]);
+        assert_eq!(out[3].1, vec![6u8]);
+
+        // Excluded start: (k02, Unbounded] — expect k03..k09.
+        let out = engine
+            .scan(Bound::Excluded("k02"), Bound::Unbounded, 100)
+            .unwrap();
+        let keys: Vec<&str> = out.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(keys, vec!["k03", "k04", "k05", "k06", "k07", "k08", "k09"]);
+
+        // Inclusive end: [k05, k07].
+        let out = engine
+            .scan(Bound::Included("k05"), Bound::Included("k07"), 100)
+            .unwrap();
+        let keys: Vec<&str> = out.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(keys, vec!["k05", "k06", "k07"]);
+    }
+
+    /// `limit` caps the result count; matches return in ascending order
+    /// from the start of the range.
+    #[test]
+    fn scan_respects_limit() {
+        let dir = tmp_dir();
+        let engine = LsmEngine::open(&dir).unwrap();
+        for i in 0u32..20 {
+            engine
+                .put(format!("k{:02}", i), vec![i as u8])
+                .unwrap();
+        }
+
+        let out = engine
+            .scan(Bound::Unbounded, Bound::Unbounded, 5)
+            .unwrap();
+        assert_eq!(out.len(), 5);
+        let keys: Vec<&str> = out.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(keys, vec!["k00", "k01", "k02", "k03", "k04"]);
+
+        // `limit = 0` returns empty without touching storage.
+        let out = engine
+            .scan(Bound::Unbounded, Bound::Unbounded, 0)
+            .unwrap();
+        assert!(out.is_empty());
+    }
+
+    /// A deleted key is invisible to `scan`, even though its tombstone is
+    /// present in storage with a higher seq than the prior `Put`.
+    #[test]
+    fn scan_filters_tombstones() {
+        let dir = tmp_dir();
+        let engine = LsmEngine::open(&dir).unwrap();
+
+        engine.put("apple".to_string(), b"red".to_vec()).unwrap();
+        engine.put("banana".to_string(), b"yellow".to_vec()).unwrap();
+        engine.put("cherry".to_string(), b"darkred".to_vec()).unwrap();
+        engine.delete("banana".to_string()).unwrap();
+
+        let out = engine
+            .scan(Bound::Unbounded, Bound::Unbounded, 100)
+            .unwrap();
+        let keys: Vec<&str> = out.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(keys, vec!["apple", "cherry"]);
+    }
+
+    /// MVCC: an overwritten key yields only its newest value.
+    #[test]
+    fn scan_returns_newest_version() {
+        let dir = tmp_dir();
+        let engine = LsmEngine::open(&dir).unwrap();
+
+        engine.put("k".to_string(), b"v1".to_vec()).unwrap();
+        engine.put("k".to_string(), b"v2".to_vec()).unwrap();
+        engine.put("k".to_string(), b"v3".to_vec()).unwrap();
+
+        let out = engine
+            .scan(Bound::Unbounded, Bound::Unbounded, 100)
+            .unwrap();
+        assert_eq!(out, vec![("k".to_string(), b"v3".to_vec())]);
+    }
+
+    /// After a flush the engine holds keys in both the memtable and an
+    /// SSTable; `scan` must merge them transparently. Uses a smallish
+    /// memtable to force a flush of the first half of the keys before the
+    /// second half is written.
+    #[test]
+    fn scan_across_memtable_and_sstable() {
+        const SMALL_MEMTABLE: usize = 32 * 1024;
+        let dir = tmp_dir();
+        let engine =
+            LsmEngine::open_with_memtable_size(&dir, SMALL_MEMTABLE).unwrap();
+
+        // First half: enough volume to fill the memtable and trigger a flush.
+        for i in 0u32..200 {
+            engine
+                .put(format!("k{:04}", i), vec![i as u8; 200])
+                .unwrap();
+        }
+        // Brief pause so the flusher can drain at least one immutable
+        // memtable. `scan_across_levels` exercises the more aggressive case.
+        std::thread::sleep(std::time::Duration::from_millis(300));
+
+        // Second half: lands in the active memtable.
+        for i in 200u32..400 {
+            engine
+                .put(format!("k{:04}", i), vec![i as u8; 200])
+                .unwrap();
+        }
+
+        let out = engine
+            .scan(Bound::Unbounded, Bound::Unbounded, 1000)
+            .unwrap();
+        assert_eq!(out.len(), 400);
+
+        // Keys must be ascending and cover every i from 0..400.
+        for (idx, (key, val)) in out.iter().enumerate() {
+            assert_eq!(*key, format!("k{:04}", idx));
+            assert_eq!(val.len(), 200);
+            assert_eq!(val[0], idx as u8);
+        }
+    }
+
+    /// Drive enough writes through a small memtable to trigger L0→L1
+    /// compaction, then scan. The merge path crosses memtable, L0, and L1.
+    #[test]
+    fn scan_across_levels() {
+        const TINY_MEMTABLE: usize = 16 * 1024;
+        let dir = tmp_dir();
+        let engine =
+            LsmEngine::open_with_memtable_size(&dir, TINY_MEMTABLE).unwrap();
+
+        // 600 keys × 100 B values = ~60 KB — plenty of flushes, kicking
+        // off L0→L1 compaction (trigger at 4 L0 files).
+        for i in 0u32..600 {
+            engine
+                .put(format!("k{:04}", i), vec![i as u8; 100])
+                .unwrap();
+        }
+        // Drain compactions.
+        std::thread::sleep(std::time::Duration::from_secs(2));
+
+        // Add a few more keys to the live memtable so the scan exercises
+        // all three sources.
+        for i in 600u32..620 {
+            engine
+                .put(format!("k{:04}", i), vec![i as u8; 100])
+                .unwrap();
+        }
+
+        // Bounded range that straddles the level boundaries.
+        let out = engine
+            .scan(Bound::Included("k0100"), Bound::Excluded("k0500"), 10_000)
+            .unwrap();
+        let keys: Vec<&str> = out.iter().map(|(k, _)| k.as_str()).collect();
+        let expected: Vec<String> =
+            (100u32..500).map(|i| format!("k{:04}", i)).collect();
+        assert_eq!(
+            keys,
+            expected.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+        );
+
+        // Full scan returns everything (620 keys).
+        let out = engine
+            .scan(Bound::Unbounded, Bound::Unbounded, 10_000)
+            .unwrap();
+        assert_eq!(out.len(), 620);
+        // Spot-check a value from each side of a likely level boundary.
+        let mid = &out[300];
+        assert_eq!(mid.0, "k0300");
+        // Value bytes are `i as u8`, so 300 wraps to 44.
+        assert_eq!(mid.1[0], 300u32 as u8);
     }
 }

--- a/src/engine/scan.rs
+++ b/src/engine/scan.rs
@@ -1,0 +1,235 @@
+//! Range scan over the engine.
+//!
+//! Reuses the existing merge-iterator machinery from `compaction`: build one
+//! `KvIterator` per source (each memtable, each overlapping SSTable), feed
+//! them all to `MergingIterator`, then layer a `ScanFilter` on top that
+//! implements the read-visible semantics — dedupe by user key (the newest
+//! version wins, since `MergingIterator` emits seq-DESC within a key), drop
+//! tombstones, honour the upper bound and the limit.
+
+use std::io;
+use std::ops::Bound;
+use std::path::Path;
+
+use crate::compaction::{MergingIterator, SsTableIterator};
+use crate::core::{KvIterator, Record};
+use crate::engine::EngineCore;
+use crate::memtable::MemTable;
+use crate::versioning::sst_path;
+
+/// Reads the engine at the current snapshot and returns up to `limit`
+/// live `(user_key, value)` pairs whose keys fall in `[start, end)` (with
+/// `Bound` flexibility on both ends), in ascending key order. Deletes are
+/// filtered out; only the newest version of each key is returned.
+pub(super) fn scan_impl(
+    core: &EngineCore,
+    start: Bound<&str>,
+    end: Bound<&str>,
+    limit: usize,
+) -> io::Result<Vec<(String, Vec<u8>)>> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+
+    // 1. Snapshot memtables + SSTable version. Each Arc clone pins the
+    //    relevant storage for the duration of this scan; concurrent flushes
+    //    and compactions may run, but their effects on the snapshot are
+    //    deferred (memtables stay alive; SstFileGuards keep files on disk).
+    let memtables = core.state.snapshot_memtables();
+    let version = core.current_version();
+
+    // 2. Build one KvIterator per source. Memtables already implement
+    //    range-aware iteration; SSTable iterators currently walk the entire
+    //    file, and `ScanFilter` discards entries outside `[start, end)`.
+    let mem_start = bound_to_owned(start);
+    let mem_end = bound_to_owned(end);
+    let mut iterators: Vec<Box<dyn KvIterator>> = Vec::new();
+
+    for table in memtables {
+        iterators.push(table.get_iterator(mem_start.clone(), mem_end.clone()));
+    }
+
+    // SSTable file collection. L0 ranges overlap, so include every L0 file
+    // whose key range intersects the scan range. L1+ are non-overlapping per
+    // level — `VersionState::overlapping_files` returns the intersecting
+    // files for each level.
+    for meta in version.files_at_level(0) {
+        if file_overlaps_scan(&meta.smallest_key, &meta.largest_key, start, end) {
+            push_sstable_iterator(&mut iterators, &sst_path(&core.data_dir, meta.file_id))?;
+        }
+    }
+    for level in 1..7usize {
+        let (lo, hi) = match (start, end) {
+            // overlapping_files works on inclusive bounds. For our purposes,
+            // a missing lower bound is conservatively treated as "" (the
+            // smallest possible string) and a missing upper bound as the
+            // string of every byte 0xFF, but in practice
+            // overlapping_files's check (`smallest_key <= hi && largest_key >= lo`)
+            // tolerates a generous range.
+            _ => (start_str(start), end_str(end)),
+        };
+        for meta in version.overlapping_files(level, lo, hi) {
+            push_sstable_iterator(&mut iterators, &sst_path(&core.data_dir, meta.file_id))?;
+        }
+    }
+
+    // 3. Merge + filter.
+    let merging = MergingIterator::new(iterators);
+    let filter = ScanFilter {
+        inner: merging,
+        start: bound_to_owned(start),
+        end: bound_to_owned(end),
+        last_key: None,
+        yielded: 0,
+        limit,
+    };
+
+    Ok(filter.collect_vec())
+}
+
+/// Adapter over `MergingIterator` that produces the read-visible scan
+/// output: one live `(key, value)` per user_key (newest version), bounded by
+/// `end` and `limit`. Tombstones are consumed silently and suppress that
+/// key entirely.
+struct ScanFilter {
+    inner: MergingIterator,
+    start: Bound<String>,
+    end: Bound<String>,
+    last_key: Option<String>,
+    yielded: usize,
+    limit: usize,
+}
+
+impl ScanFilter {
+    fn collect_vec(mut self) -> Vec<(String, Vec<u8>)> {
+        let mut out: Vec<(String, Vec<u8>)> = Vec::new();
+        while self.yielded < self.limit {
+            match self.inner.next() {
+                None => break,
+                Some((key, record, _seq)) => {
+                    // Upper-bound check first — entries are emitted in
+                    // ascending order, so once we cross `end` we're done.
+                    if past_end(&key, &self.end) {
+                        break;
+                    }
+                    // Lower-bound check. Memtable iterators are already
+                    // bounded, but SSTable iterators walk the whole file —
+                    // so without this filter, sub-start keys from SSTables
+                    // leak through. We skip without touching `last_key`
+                    // because no key < start can ever be one we'd yield
+                    // later (entries arrive in ascending order).
+                    if before_start(&key, &self.start) {
+                        continue;
+                    }
+                    // Dedup: skip older versions of an already-emitted key.
+                    if self.last_key.as_deref() == Some(key.as_str()) {
+                        continue;
+                    }
+                    self.last_key = Some(key.clone());
+                    // Drop tombstones — they suppress the key from output.
+                    match record {
+                        Record::Put(value) => {
+                            out.push((key, value));
+                            self.yielded += 1;
+                        }
+                        Record::Delete => {
+                            // Tombstone consumed; `last_key` was bumped above
+                            // so the next-older Put for the same key is also
+                            // skipped on its own iteration.
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn bound_to_owned(b: Bound<&str>) -> Bound<String> {
+    match b {
+        Bound::Included(s) => Bound::Included(s.to_string()),
+        Bound::Excluded(s) => Bound::Excluded(s.to_string()),
+        Bound::Unbounded => Bound::Unbounded,
+    }
+}
+
+fn past_end(key: &str, end: &Bound<String>) -> bool {
+    match end {
+        Bound::Included(e) => key > e.as_str(),
+        Bound::Excluded(e) => key >= e.as_str(),
+        Bound::Unbounded => false,
+    }
+}
+
+fn before_start(key: &str, start: &Bound<String>) -> bool {
+    match start {
+        Bound::Included(s) => key < s.as_str(),
+        Bound::Excluded(s) => key <= s.as_str(),
+        Bound::Unbounded => false,
+    }
+}
+
+/// String form of the lower bound used by `version.overlapping_files`.
+/// `overlapping_files` filters by `smallest_key <= hi && largest_key >= lo`;
+/// for an `Unbounded` lower we want the lowest possible string, "".
+fn start_str(b: Bound<&str>) -> &str {
+    match b {
+        Bound::Included(s) | Bound::Excluded(s) => s,
+        Bound::Unbounded => "",
+    }
+}
+
+/// String form of the upper bound. For `Unbounded` upper we use the highest
+/// reachable string for our keys, which we approximate with "\u{10FFFF}"
+/// (every key compares less). This is only used to *pre-filter* SSTables;
+/// `ScanFilter` does the precise bound check on each emitted key, so a few
+/// extra files getting scanned is at worst a perf cost.
+fn end_str(b: Bound<&str>) -> &str {
+    match b {
+        Bound::Included(s) | Bound::Excluded(s) => s,
+        Bound::Unbounded => "\u{10FFFF}",
+    }
+}
+
+/// Returns true when `[smallest, largest]` intersects the scan range
+/// `[start, end)`. Used to prune L0 files that lie entirely outside the
+/// scan range — `version.overlapping_files` covers the L1+ case via the
+/// version state.
+fn file_overlaps_scan(
+    smallest: &str,
+    largest: &str,
+    start: Bound<&str>,
+    end: Bound<&str>,
+) -> bool {
+    let after_start = match start {
+        Bound::Included(s) => largest >= s,
+        Bound::Excluded(s) => largest > s,
+        Bound::Unbounded => true,
+    };
+    let before_end = match end {
+        Bound::Included(e) => smallest <= e,
+        Bound::Excluded(e) => smallest < e,
+        Bound::Unbounded => true,
+    };
+    after_start && before_end
+}
+
+fn push_sstable_iterator(
+    iterators: &mut Vec<Box<dyn KvIterator>>,
+    path: &Path,
+) -> io::Result<()> {
+    match SsTableIterator::open(path) {
+        Ok(iter) => {
+            iterators.push(Box::new(iter));
+            Ok(())
+        }
+        Err(e) => Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("scan: failed to open SSTable {:?}: {}", path, e),
+        )),
+    }
+}

--- a/src/flusher/mod.rs
+++ b/src/flusher/mod.rs
@@ -97,7 +97,6 @@ fn flush_pending(engine: &EngineCore) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::engine::LsmEngine;
     use std::sync::atomic::Ordering;
     use std::time::Duration;

--- a/src/memtable/state.rs
+++ b/src/memtable/state.rs
@@ -114,6 +114,24 @@ impl MemTableState {
         self.inner.read().unwrap().immutable.len()
     }
 
+    /// Atomic snapshot of every memtable currently visible to readers: the
+    /// active memtable followed by each immutable memtable in oldest-first
+    /// order. Used by `LsmEngine::scan` to build a consistent view across
+    /// memtable + SSTable storage.
+    ///
+    /// The Arc clones make this cheap and lock-free for the duration of the
+    /// scan — concurrent writes still proceed on the live memtable, but they
+    /// won't be reflected in this snapshot.
+    pub fn snapshot_memtables(&self) -> Vec<Arc<CrossbeamMemTable>> {
+        let guard = self.inner.read().unwrap();
+        let mut out = Vec::with_capacity(guard.immutable.len() + 1);
+        out.push(Arc::clone(&guard.active));
+        for table in guard.immutable.iter() {
+            out.push(Arc::clone(table));
+        }
+        out
+    }
+
     /// Blocks the calling thread until the immutable queue drops below the
     /// backpressure threshold. Returns `true` if the wait completed normally,
     /// `false` if the timeout expired while still stalled.

--- a/src/server.rs
+++ b/src/server.rs
@@ -134,6 +134,18 @@ mod tests {
             self.inner.lock().unwrap().remove(&key);
             Ok(())
         }
+
+        async fn scan(
+            &self,
+            _start: std::ops::Bound<String>,
+            _end: std::ops::Bound<String>,
+            _limit: usize,
+        ) -> Result<Vec<(String, Vec<u8>)>, EngineError> {
+            // The router does not (yet) expose `/scan`, so this mock impl is
+            // unused. Returns empty rather than panicking so any future
+            // accidental call from a test still produces a well-formed result.
+            Ok(Vec::new())
+        }
     }
 
     fn router_with(engine: Arc<MockEngine>) -> Router {

--- a/src/sstable/writer.rs
+++ b/src/sstable/writer.rs
@@ -7,7 +7,7 @@ use bloomfilter::Bloom;
 use crate::core::{InternalKey, KvIterator, Record};
 use crate::sstable::block::BlockBuilder;
 use crate::sstable::{
-    FOOTER_SIZE, INDEX_OFFSET_SIZE, IndexOffset, MAGIC_NUMBER, MAGIC_SIZE, MagicNumber, META_OFFSET_SIZE,
+    FOOTER_SIZE, INDEX_OFFSET_SIZE, IndexOffset, MAGIC_NUMBER, MAGIC_SIZE, META_OFFSET_SIZE,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -378,6 +378,7 @@ impl SsTableBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sstable::MagicNumber;
     use crate::sstable::{MetaOffset, IndexOffset};
     use crate::sstable::block::Block;
     use std::fs;


### PR DESCRIPTION
`LsmEngine` had `put`, `get`, and `delete` only — anything that needs to iterate keys in order (YCSB-E, prefix listings, "give me the next N keys after X") was unimplementable. This adds `scan` on both the sync engine API and the async `StorageEngine` trait, reusing the existing merge-iterator machinery from compaction.

The follow-up commit adds the `/scan` HTTP endpoint to the server; this PR only touches the in-process Rust API.

Engine API:
  - `LsmEngine::scan(start: Bound<&str>, end: Bound<&str>, limit) ->
    io::Result<Vec<(String, Vec<u8>)>>` — sync, on the core engine.
  - `StorageEngine::scan(start: Bound<String>, end: Bound<String>, limit) -> Result<…, EngineError>` — async trait method, owned bounds because the future is `'static` once spawned.
  - `LsmHandle::scan` follows the existing `spawn_blocking` pattern.

Implementation (`src/engine/scan.rs`):
  - Snapshot acquisition: `state.snapshot_memtables()` (new) clones Arcs of active + every immutable memtable atomically; `current_version()` pins SSTable files via `SstFileGuard` for the duration of the scan.
  - Per-source iterators: one per memtable via the existing `MemTable::get_iterator(low, high)`, one per overlapping SSTable via `SsTableIterator::open`. L0 files all overlap so each one is checked against `[start, end)`; L1+ goes through `version.overlapping_files`.
  - k-way merge via the existing `MergingIterator` (now `pub(crate)`), then a new `ScanFilter` wrapper that handles upper-bound checking, lower-bound checking (necessary because `SsTableIterator` walks the whole file, so sub-start keys from SSTables would otherwise leak through), MVCC dedup (skip older versions of an already-emitted user_key), tombstone suppression (deletes consume their key without yielding), and the limit.

Visibility tweaks: `MergingIterator`, `SsTableIterator`, and their constructors in `src/compaction/mod.rs` → `pub(crate)`. New `MemTableState::snapshot_memtables` getter.

Tests (7 new, all passing):
  - empty engine returns empty
  - Bound::{Included, Excluded, Unbounded} on both ends
  - limit caps the result; limit=0 short-circuits
  - tombstones suppress their key
  - MVCC picks the newest version on overwrite
  - merge across memtable + SSTable (after a flush)
  - merge across levels (small memtable forces L0→L1 compaction)

Also: small unused-import cleanups in `src/flusher/mod.rs` and `src/sstable/writer.rs` flagged by the build's lint warnings.