### PR TITLE
Return an iterator from LsmEngine::scan

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -337,20 +337,29 @@ impl EngineCore {
         Ok(())
     }
 
-    /// Range scan: returns up to `limit` live `(user_key, value)` pairs whose
-    /// keys fall in the range described by `start` and `end` (both `Bound`),
-    /// in ascending key order. Tombstones suppress their key from the output;
-    /// only the newest version of each key is returned.
+    /// Range scan: returns an iterator over up to `limit` live
+    /// `(user_key, value)` pairs whose keys fall in the range described by
+    /// `start` and `end` (both `Bound`), in ascending key order. Tombstones
+    /// suppress their key from the output; only the newest version of each
+    /// key is returned.
     ///
-    /// Snapshot semantics: the scan observes a consistent point-in-time view
-    /// of the engine. Concurrent writes that arrive after the call begins are
-    /// not reflected.
+    /// Snapshot semantics: the scan observes a consistent point-in-time
+    /// view of the engine. Concurrent writes that arrive after `scan` is
+    /// called are not reflected, even if the caller polls the iterator
+    /// later.
+    ///
+    /// The iterator is `'static` — it owns Arcs to the snapshotted
+    /// memtables and the SSTable version, plus open file handles for any
+    /// SSTables it might read. Callers can hold it across `await` points
+    /// or drop it mid-stream without leaking state. `LsmHandle::scan`
+    /// collects this iterator into a `Vec` for the `StorageEngine` trait;
+    /// in-process consumers can stream record-by-record instead.
     pub fn scan(
         &self,
         start: std::ops::Bound<&str>,
         end: std::ops::Bound<&str>,
         limit: usize,
-    ) -> io::Result<Vec<(String, Vec<u8>)>> {
+    ) -> io::Result<impl Iterator<Item = (String, Vec<u8>)>> {
         scan::scan_impl(self, start, end, limit)
     }
 
@@ -527,7 +536,11 @@ impl StorageEngine for LsmHandle {
     ) -> Result<Vec<(String, Vec<u8>)>, EngineError> {
         let engine = Arc::clone(&self.inner);
         tokio::task::spawn_blocking(move || {
-            engine.scan(bound_as_ref(&start), bound_as_ref(&end), limit)
+            // The sync API returns an iterator; the async trait contract
+            // is a Vec, so we collect inside the blocking task.
+            engine
+                .scan(bound_as_ref(&start), bound_as_ref(&end), limit)
+                .map(|it| it.collect::<Vec<_>>())
         })
         .await
         .expect("spawn_blocking panicked")
@@ -1268,9 +1281,10 @@ mod tests {
     fn scan_empty_engine_returns_empty() {
         let dir = tmp_dir();
         let engine = LsmEngine::open(&dir).unwrap();
-        let out = engine
+        let out: Vec<_> = engine
             .scan(Bound::Unbounded, Bound::Unbounded, 100)
-            .unwrap();
+            .unwrap()
+            .collect();
         assert!(out.is_empty());
     }
 
@@ -1289,9 +1303,10 @@ mod tests {
         }
 
         // [k03, k07) — Included start, Excluded end. Expect k03..k06.
-        let out = engine
+        let out: Vec<_> = engine
             .scan(Bound::Included("k03"), Bound::Excluded("k07"), 100)
-            .unwrap();
+            .unwrap()
+            .collect();
         let keys: Vec<&str> = out.iter().map(|(k, _)| k.as_str()).collect();
         assert_eq!(keys, vec!["k03", "k04", "k05", "k06"]);
 
@@ -1300,16 +1315,18 @@ mod tests {
         assert_eq!(out[3].1, vec![6u8]);
 
         // Excluded start: (k02, Unbounded] — expect k03..k09.
-        let out = engine
+        let out: Vec<_> = engine
             .scan(Bound::Excluded("k02"), Bound::Unbounded, 100)
-            .unwrap();
+            .unwrap()
+            .collect();
         let keys: Vec<&str> = out.iter().map(|(k, _)| k.as_str()).collect();
         assert_eq!(keys, vec!["k03", "k04", "k05", "k06", "k07", "k08", "k09"]);
 
         // Inclusive end: [k05, k07].
-        let out = engine
+        let out: Vec<_> = engine
             .scan(Bound::Included("k05"), Bound::Included("k07"), 100)
-            .unwrap();
+            .unwrap()
+            .collect();
         let keys: Vec<&str> = out.iter().map(|(k, _)| k.as_str()).collect();
         assert_eq!(keys, vec!["k05", "k06", "k07"]);
     }
@@ -1326,17 +1343,19 @@ mod tests {
                 .unwrap();
         }
 
-        let out = engine
+        let out: Vec<_> = engine
             .scan(Bound::Unbounded, Bound::Unbounded, 5)
-            .unwrap();
+            .unwrap()
+            .collect();
         assert_eq!(out.len(), 5);
         let keys: Vec<&str> = out.iter().map(|(k, _)| k.as_str()).collect();
         assert_eq!(keys, vec!["k00", "k01", "k02", "k03", "k04"]);
 
         // `limit = 0` returns empty without touching storage.
-        let out = engine
+        let out: Vec<_> = engine
             .scan(Bound::Unbounded, Bound::Unbounded, 0)
-            .unwrap();
+            .unwrap()
+            .collect();
         assert!(out.is_empty());
     }
 
@@ -1352,9 +1371,10 @@ mod tests {
         engine.put("cherry".to_string(), b"darkred".to_vec()).unwrap();
         engine.delete("banana".to_string()).unwrap();
 
-        let out = engine
+        let out: Vec<_> = engine
             .scan(Bound::Unbounded, Bound::Unbounded, 100)
-            .unwrap();
+            .unwrap()
+            .collect();
         let keys: Vec<&str> = out.iter().map(|(k, _)| k.as_str()).collect();
         assert_eq!(keys, vec!["apple", "cherry"]);
     }
@@ -1369,9 +1389,10 @@ mod tests {
         engine.put("k".to_string(), b"v2".to_vec()).unwrap();
         engine.put("k".to_string(), b"v3".to_vec()).unwrap();
 
-        let out = engine
+        let out: Vec<_> = engine
             .scan(Bound::Unbounded, Bound::Unbounded, 100)
-            .unwrap();
+            .unwrap()
+            .collect();
         assert_eq!(out, vec![("k".to_string(), b"v3".to_vec())]);
     }
 
@@ -1403,9 +1424,10 @@ mod tests {
                 .unwrap();
         }
 
-        let out = engine
+        let out: Vec<_> = engine
             .scan(Bound::Unbounded, Bound::Unbounded, 1000)
-            .unwrap();
+            .unwrap()
+            .collect();
         assert_eq!(out.len(), 400);
 
         // Keys must be ascending and cover every i from 0..400.
@@ -1444,9 +1466,10 @@ mod tests {
         }
 
         // Bounded range that straddles the level boundaries.
-        let out = engine
+        let out: Vec<_> = engine
             .scan(Bound::Included("k0100"), Bound::Excluded("k0500"), 10_000)
-            .unwrap();
+            .unwrap()
+            .collect();
         let keys: Vec<&str> = out.iter().map(|(k, _)| k.as_str()).collect();
         let expected: Vec<String> =
             (100u32..500).map(|i| format!("k{:04}", i)).collect();
@@ -1456,9 +1479,10 @@ mod tests {
         );
 
         // Full scan returns everything (620 keys).
-        let out = engine
+        let out: Vec<_> = engine
             .scan(Bound::Unbounded, Bound::Unbounded, 10_000)
-            .unwrap();
+            .unwrap()
+            .collect();
         assert_eq!(out.len(), 620);
         // Spot-check a value from each side of a likely level boundary.
         let mid = &out[300];

--- a/src/engine/scan.rs
+++ b/src/engine/scan.rs
@@ -17,19 +17,26 @@ use crate::engine::EngineCore;
 use crate::memtable::MemTable;
 use crate::versioning::sst_path;
 
-/// Reads the engine at the current snapshot and returns up to `limit`
-/// live `(user_key, value)` pairs whose keys fall in `[start, end)` (with
-/// `Bound` flexibility on both ends), in ascending key order. Deletes are
-/// filtered out; only the newest version of each key is returned.
+/// Reads the engine at the current snapshot and returns an iterator over up
+/// to `limit` live `(user_key, value)` pairs whose keys fall in
+/// `[start, end)` (with `Bound` flexibility on both ends), in ascending key
+/// order. Deletes are filtered out; only the newest version of each key is
+/// returned.
+///
+/// The returned iterator is `'static` — it owns Arcs to the snapshotted
+/// memtables and the SSTable version, plus the open file handles for any
+/// SSTables it might read. Callers can hold it across `await` points or
+/// drop it mid-stream without leaking state.
 pub(super) fn scan_impl(
     core: &EngineCore,
     start: Bound<&str>,
     end: Bound<&str>,
     limit: usize,
-) -> io::Result<Vec<(String, Vec<u8>)>> {
-    if limit == 0 {
-        return Ok(Vec::new());
-    }
+) -> io::Result<ScanFilter> {
+    // Build the snapshot + per-source iterators even when limit == 0; the
+    // ScanFilter's while-condition (`self.yielded < self.limit`) will then
+    // short-circuit on the first call to `next()`. Slightly more work than
+    // an explicit early-return, but keeps the construction path uniform.
 
     // 1. Snapshot memtables + SSTable version. Each Arc clone pins the
     //    relevant storage for the duration of this scan; concurrent flushes
@@ -73,25 +80,28 @@ pub(super) fn scan_impl(
         }
     }
 
-    // 3. Merge + filter.
+    // 3. Merge + filter. The ScanFilter is returned as an iterator — the
+    //    caller drives it lazily and can stop early by dropping it.
     let merging = MergingIterator::new(iterators);
-    let filter = ScanFilter {
+    Ok(ScanFilter {
         inner: merging,
         start: bound_to_owned(start),
         end: bound_to_owned(end),
         last_key: None,
         yielded: 0,
         limit,
-    };
-
-    Ok(filter.collect_vec())
+    })
 }
 
 /// Adapter over `MergingIterator` that produces the read-visible scan
 /// output: one live `(key, value)` per user_key (newest version), bounded by
 /// `end` and `limit`. Tombstones are consumed silently and suppress that
 /// key entirely.
-struct ScanFilter {
+///
+/// Exposed as a public `Iterator` from `LsmEngine::scan` so callers can
+/// process results lazily — useful for large ranges where materialising
+/// the full `Vec` upfront would cost memory.
+pub(crate) struct ScanFilter {
     inner: MergingIterator,
     start: Bound<String>,
     end: Bound<String>,
@@ -100,48 +110,43 @@ struct ScanFilter {
     limit: usize,
 }
 
-impl ScanFilter {
-    fn collect_vec(mut self) -> Vec<(String, Vec<u8>)> {
-        let mut out: Vec<(String, Vec<u8>)> = Vec::new();
+impl Iterator for ScanFilter {
+    type Item = (String, Vec<u8>);
+
+    fn next(&mut self) -> Option<(String, Vec<u8>)> {
         while self.yielded < self.limit {
-            match self.inner.next() {
-                None => break,
-                Some((key, record, _seq)) => {
-                    // Upper-bound check first — entries are emitted in
-                    // ascending order, so once we cross `end` we're done.
-                    if past_end(&key, &self.end) {
-                        break;
-                    }
-                    // Lower-bound check. Memtable iterators are already
-                    // bounded, but SSTable iterators walk the whole file —
-                    // so without this filter, sub-start keys from SSTables
-                    // leak through. We skip without touching `last_key`
-                    // because no key < start can ever be one we'd yield
-                    // later (entries arrive in ascending order).
-                    if before_start(&key, &self.start) {
-                        continue;
-                    }
-                    // Dedup: skip older versions of an already-emitted key.
-                    if self.last_key.as_deref() == Some(key.as_str()) {
-                        continue;
-                    }
-                    self.last_key = Some(key.clone());
-                    // Drop tombstones — they suppress the key from output.
-                    match record {
-                        Record::Put(value) => {
-                            out.push((key, value));
-                            self.yielded += 1;
-                        }
-                        Record::Delete => {
-                            // Tombstone consumed; `last_key` was bumped above
-                            // so the next-older Put for the same key is also
-                            // skipped on its own iteration.
-                        }
-                    }
+            let (key, record, _seq) = self.inner.next()?;
+
+            // Upper-bound check first — entries arrive in ascending key
+            // order, so once we cross `end` no later entry can match.
+            if past_end(&key, &self.end) {
+                return None;
+            }
+            // Lower-bound check. Memtable iterators are already bounded,
+            // but SSTable iterators walk the whole file — so without this
+            // filter, sub-start keys from SSTables would leak through. We
+            // skip without touching `last_key`: no key < start can ever be
+            // one we'd yield later (ascending order).
+            if before_start(&key, &self.start) {
+                continue;
+            }
+            // Dedup: skip older versions of an already-emitted key.
+            if self.last_key.as_deref() == Some(key.as_str()) {
+                continue;
+            }
+            self.last_key = Some(key.clone());
+            // Drop tombstones — they suppress the key from output. The
+            // `last_key` bump above ensures any older `Put` for the same
+            // key is also skipped on its own iteration.
+            match record {
+                Record::Put(value) => {
+                    self.yielded += 1;
+                    return Some((key, value));
                 }
+                Record::Delete => continue,
             }
         }
-        out
+        None
     }
 }
 


### PR DESCRIPTION
The sync engine API materialised every scan result into a `Vec<(String, Vec<u8>)>` before returning, even for in-process consumers that wanted to stream record-by-record. Switch the sync API to return `impl Iterator<Item = (String, Vec<u8>)>` so callers can process records lazily, cap memory at one entry at a time, and cancel mid-scan by dropping the iterator.

Why this works without lifetime gymnastics:
  every iterator in the scan pipeline (MemTable::get_iterator,
  SsTableIterator, MergingIterator) is already `'static` — they hold
  Arcs to the snapshotted memtables / version state rather than
  borrowing from `&self`. So the returned iterator is also `'static`,
  no `'_` bound on the API.

Implementation:
  - src/engine/scan.rs: ScanFilter now implements Iterator<Item = (String, Vec<u8>)>. The old `collect_vec` body became the `next` loop with the same filter / dedup / tombstone / bound / limit logic, re-shaped one record at a time. The `limit=0` fast path is gone; the while-condition (`yielded < limit`) short-circuits on the first call to `next()`.
  - src/engine/mod.rs: LsmEngine::scan signature change. LsmHandle::scan (the async trait impl) collects inside spawn_blocking via `.map(|it| it.collect::<Vec<_>>())` — async trait contract is unchanged, the collection just happens on the blocking pool.

What's deliberately not changed:
  - StorageEngine::scan still returns Vec. Stream-shaped async traits are a much bigger refactor (futures::Stream + GAT-style impl Trait in trait methods) and aren't needed here.
  - src/server.rs and the /kv HTTP handler unaffected — they go through the async trait, so they still see Vec.
  - MockEngine::scan in src/server::tests still implements the Vec trait method.

Tests: 7 scan tests in src/engine/mod.rs get `.collect::<Vec<_>>()` appended after `.unwrap()`. Same assertions, same coverage — the mechanical change confirms the lazy iterator preserves every contract the eager Vec version did (empty, bounds, limit, tombstones, MVCC dedup, memtable + SSTable merge, cross-level merge). 160 lib tests still pass; no logic shifts anywhere else.