### PR TITLE
Add YCSB-E to the benchmark harness

### DIFF
--- a/src/bin/README.md
+++ b/src/bin/README.md
@@ -123,8 +123,10 @@ remain useful for quick smoke tests during development.
 | `--update-pct <f>`         | `0.5`              | Fraction of ops that are updates.    |
 | `--insert-pct <f>`         | `0.0`              | Fraction that are inserts (grows key space). |
 | `--rmw-pct <f>`            | `0.0`              | Fraction that are read-modify-write. |
+| `--scan-pct <f>`           | `0.0`              | Fraction that are range scans.       |
+| `--max-scan-length <N>`    | `100`              | Upper bound on per-scan record count (uniform [1, N]). |
 
-The four `--*-pct` flags must sum to `1.0`. If `--config` is set, the TOML
+The five `--*-pct` flags must sum to `1.0`. If `--config` is set, the TOML
 provides the workload and CLI flags act as field-level overrides; setting
 *any* `--*-pct` flag replaces the entire op mix wholesale (to keep the
 sum-to-1 invariant).
@@ -225,5 +227,3 @@ spikes in time; the summary is the authoritative tail-latency view.
 
 - **Sleep precision on macOS.** See the closed-loop caveat above. Linux is
   the answer.
-- **No `scan` workload (YCSB-E).** `LsmEngine` has no public `scan` API;
-  adding one is a separate engine feature, not part of the harness phasing.

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -39,6 +39,14 @@ struct Workload {
     #[serde(default = "default_theta")]
     zipfian_theta: f64,
     op_mix: OpMix,
+    /// Upper bound on per-scan record count. Each scan op picks a length
+    /// uniformly from `[1, max_scan_length]`. Default 100 per YCSB-E.
+    #[serde(default = "default_max_scan_length")]
+    max_scan_length: usize,
+}
+
+fn default_max_scan_length() -> usize {
+    100
 }
 
 fn default_theta() -> f64 {
@@ -75,6 +83,8 @@ struct OpMix {
     insert: f64,
     #[serde(default)]
     rmw: f64,
+    #[serde(default)]
+    scan: f64,
 }
 
 impl OpMix {
@@ -84,16 +94,17 @@ impl OpMix {
             ("update", self.update),
             ("insert", self.insert),
             ("rmw", self.rmw),
+            ("scan", self.scan),
         ] {
             if v < 0.0 {
                 return Err(format!("op_mix.{} = {} is negative", name, v));
             }
         }
-        let sum = self.read + self.update + self.insert + self.rmw;
+        let sum = self.read + self.update + self.insert + self.rmw + self.scan;
         if (sum - 1.0).abs() > 1e-6 {
             return Err(format!(
-                "op_mix sums to {} (read={}, update={}, insert={}, rmw={}); expected 1.0",
-                sum, self.read, self.update, self.insert, self.rmw,
+                "op_mix sums to {} (read={}, update={}, insert={}, rmw={}, scan={}); expected 1.0",
+                sum, self.read, self.update, self.insert, self.rmw, self.scan,
             ));
         }
         Ok(())
@@ -106,6 +117,7 @@ enum OpKind {
     Update,
     Insert,
     Rmw,
+    Scan,
 }
 
 // ---------------------------------------------------------------------------
@@ -158,7 +170,8 @@ struct OpSampler {
     read: f64,
     update_cum: f64,
     insert_cum: f64,
-    // rmw fills the rest.
+    rmw_cum: f64,
+    // scan fills the rest.
 }
 
 impl OpSampler {
@@ -167,6 +180,7 @@ impl OpSampler {
             read: mix.read,
             update_cum: mix.read + mix.update,
             insert_cum: mix.read + mix.update + mix.insert,
+            rmw_cum: mix.read + mix.update + mix.insert + mix.rmw,
         }
     }
 
@@ -177,8 +191,10 @@ impl OpSampler {
             OpKind::Update
         } else if r < self.insert_cum {
             OpKind::Insert
-        } else {
+        } else if r < self.rmw_cum {
             OpKind::Rmw
+        } else {
+            OpKind::Scan
         }
     }
 }
@@ -265,6 +281,15 @@ struct Args {
     /// Fraction of ops that are read-modify-write (get followed by put).
     #[arg(long)]
     rmw_pct: Option<f64>,
+
+    /// Fraction of ops that are range scans.
+    #[arg(long)]
+    scan_pct: Option<f64>,
+
+    /// Upper bound on per-scan record count. Each scan op picks a length
+    /// uniformly from `[1, max_scan_length]`. Default 100 per YCSB-E.
+    #[arg(long)]
+    max_scan_length: Option<usize>,
 }
 
 fn default_workload() -> Workload {
@@ -280,7 +305,9 @@ fn default_workload() -> Workload {
             update: 0.5,
             insert: 0.0,
             rmw: 0.0,
+            scan: 0.0,
         },
+        max_scan_length: 100,
     }
 }
 
@@ -314,13 +341,18 @@ fn resolve_workload(args: &Args) -> Result<Workload, Box<dyn std::error::Error>>
         || args.update_pct.is_some()
         || args.insert_pct.is_some()
         || args.rmw_pct.is_some()
+        || args.scan_pct.is_some()
     {
         workload.op_mix = OpMix {
             read: args.read_pct.unwrap_or(0.0),
             update: args.update_pct.unwrap_or(0.0),
             insert: args.insert_pct.unwrap_or(0.0),
             rmw: args.rmw_pct.unwrap_or(0.0),
+            scan: args.scan_pct.unwrap_or(0.0),
         };
+    }
+    if let Some(v) = args.max_scan_length {
+        workload.max_scan_length = v;
     }
 
     workload.op_mix.validate()?;
@@ -360,11 +392,13 @@ struct ThreadResult {
     updates: u64,
     inserts: u64,
     rmws: u64,
+    scans: u64,
     read_hits: u64,
     read_hist: Histogram<u64>,
     update_hist: Histogram<u64>,
     insert_hist: Histogram<u64>,
     rmw_hist: Histogram<u64>,
+    scan_hist: Histogram<u64>,
     /// Per-second window snapshots produced by this worker. Only populated
     /// when CSV output is enabled (otherwise this stays empty to save the
     /// extra bookkeeping cost).
@@ -380,6 +414,7 @@ struct WindowBucket {
     updates: u64,
     inserts: u64,
     rmws: u64,
+    scans: u64,
     /// Combined histogram covering every op kind in this window. We don't
     /// split per kind here — the cumulative per-op-kind histograms on
     /// `ThreadResult` already serve the per-op-kind summary.
@@ -394,6 +429,7 @@ impl WindowBucket {
             updates: 0,
             inserts: 0,
             rmws: 0,
+            scans: 0,
             hist: Histogram::<u64>::new(3).map_err(|e| e.to_string())?,
         })
     }
@@ -435,11 +471,13 @@ fn run_worker(
     let mut update_hist: Histogram<u64> = Histogram::new(3).map_err(|e| e.to_string())?;
     let mut insert_hist: Histogram<u64> = Histogram::new(3).map_err(|e| e.to_string())?;
     let mut rmw_hist: Histogram<u64> = Histogram::new(3).map_err(|e| e.to_string())?;
+    let mut scan_hist: Histogram<u64> = Histogram::new(3).map_err(|e| e.to_string())?;
 
     let mut reads: u64 = 0;
     let mut updates: u64 = 0;
     let mut inserts: u64 = 0;
     let mut rmws: u64 = 0;
+    let mut scans: u64 = 0;
     let mut read_hits: u64 = 0;
 
     // Per-second window bookkeeping (only used when record_windows is true).
@@ -507,6 +545,26 @@ fn run_worker(
                 rmws += 1;
                 OpKind::Rmw
             }
+            OpKind::Scan => {
+                let start_key = make_key(key_sampler.sample(&mut rng, n_current));
+                // YCSB-E: per-scan length is uniformly random in
+                // [1, max_scan_length]. The engine's `limit` arg caps the
+                // iterator output, so we don't need a separate counter here.
+                let scan_len = rng.random_range(1..=workload.max_scan_length);
+                let iter = engine
+                    .scan(
+                        std::ops::Bound::Included(start_key.as_str()),
+                        std::ops::Bound::Unbounded,
+                        scan_len,
+                    )
+                    .map_err(|e| e.to_string())?;
+                // Drive the iterator to completion. Measuring scan
+                // throughput is about pulling each record from the merging
+                // pipeline; we don't materialise the records anywhere.
+                for _ in iter {}
+                scans += 1;
+                OpKind::Scan
+            }
         };
         let op_complete = Instant::now();
 
@@ -523,6 +581,7 @@ fn run_worker(
             OpKind::Update => &mut update_hist,
             OpKind::Insert => &mut insert_hist,
             OpKind::Rmw => &mut rmw_hist,
+            OpKind::Scan => &mut scan_hist,
         };
         match interval_ns {
             Some(ivl) => hist
@@ -549,6 +608,7 @@ fn run_worker(
                 OpKind::Update => cw.updates += 1,
                 OpKind::Insert => cw.inserts += 1,
                 OpKind::Rmw => cw.rmws += 1,
+                OpKind::Scan => cw.scans += 1,
             }
             // We record the actual elapsed latency in the window even in
             // closed-loop mode — the CO-corrected histogram is for the final
@@ -571,11 +631,13 @@ fn run_worker(
         updates,
         inserts,
         rmws,
+        scans,
         read_hits,
         read_hist,
         update_hist,
         insert_hist,
         rmw_hist,
+        scan_hist,
         windows,
     })
 }
@@ -726,10 +788,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut combined_update: Histogram<u64> = Histogram::new(3)?;
     let mut combined_insert: Histogram<u64> = Histogram::new(3)?;
     let mut combined_rmw: Histogram<u64> = Histogram::new(3)?;
+    let mut combined_scan: Histogram<u64> = Histogram::new(3)?;
     let mut reads = 0u64;
     let mut updates = 0u64;
     let mut inserts = 0u64;
     let mut rmws = 0u64;
+    let mut scans = 0u64;
     let mut read_hits = 0u64;
     let mut all_windows: Vec<WindowBucket> = Vec::new();
 
@@ -741,10 +805,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         combined_update.add(result.update_hist)?;
         combined_insert.add(result.insert_hist)?;
         combined_rmw.add(result.rmw_hist)?;
+        combined_scan.add(result.scan_hist)?;
         reads += result.reads;
         updates += result.updates;
         inserts += result.inserts;
         rmws += result.rmws;
+        scans += result.scans;
         read_hits += result.read_hits;
         all_windows.append(&mut result.windows);
     }
@@ -756,7 +822,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let run_elapsed = run_start.elapsed();
-    let total_ops = reads + updates + inserts + rmws;
+    let total_ops = reads + updates + inserts + rmws + scans;
     let n_final = next_insert_idx.load(Ordering::Relaxed);
 
     // ---- Report ---------------------------------------------------------
@@ -779,12 +845,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("  zipf_theta:  {}", workload.zipfian_theta);
     }
     println!(
-        "  op_mix:      read={:.2} update={:.2} insert={:.2} rmw={:.2}",
+        "  op_mix:      read={:.2} update={:.2} insert={:.2} rmw={:.2} scan={:.2}",
         workload.op_mix.read,
         workload.op_mix.update,
         workload.op_mix.insert,
         workload.op_mix.rmw,
+        workload.op_mix.scan,
     );
+    if workload.op_mix.scan > 0.0 {
+        println!("  max_scan_len: {}", workload.max_scan_length);
+    }
     println!("config:");
     println!("  dir:         {:?}", args.dir);
     println!("  threads:     {}", args.threads);
@@ -814,6 +884,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("  updates:     {} ({:.1}%)", updates, pct(updates));
     println!("  inserts:     {} ({:.1}%)", inserts, pct(inserts));
     println!("  rmw:         {} ({:.1}%)", rmws, pct(rmws));
+    println!("  scans:       {} ({:.1}%)", scans, pct(scans));
     println!(
         "  key space:   {} (initial) → {} (final)",
         workload.keys, n_final,
@@ -828,6 +899,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     print_per_op_block("updates", updates, &combined_update);
     print_per_op_block("inserts", inserts, &combined_insert);
     print_per_op_block("rmw    ", rmws, &combined_rmw);
+    print_per_op_block("scans  ", scans, &combined_scan);
 
     // ---- Time-series CSV ------------------------------------------------
     if let Some(csv_path) = &args.csv {

--- a/workloads/README.md
+++ b/workloads/README.md
@@ -16,11 +16,12 @@ cargo run --release --bin bench -- \
 | `ycsb-b.toml` | B         | 95% read / 5% update          | Zipfian (θ=0.99)  | Read-mostly with light updates     |
 | `ycsb-c.toml` | C         | 100% read                     | Zipfian (θ=0.99)  | Read-only baseline                 |
 | `ycsb-d.toml` | D         | 95% read / 5% insert          | Latest            | Read-latest with growing key space |
+| `ycsb-e.toml` | E         | 95% scan / 5% insert          | Zipfian (θ=0.99)  | Short range scans (length 1–100)   |
 | `ycsb-f.toml` | F         | 50% read / 50% RMW            | Zipfian (θ=0.99)  | Read-modify-write                  |
 
-YCSB-E (short range scans) is intentionally omitted — `LsmEngine` does not
-yet expose a public scan API. Adding one is a separate engine feature, not
-part of the benchmark harness.
+YCSB-E uses range scans with per-op length sampled uniformly from
+`[1, max_scan_length]` (default `100`, matching the YCSB paper). Override
+via `--max-scan-length`.
 
 All presets default to **1 million keys × 1 KB values**. Override any field
 at run time with the corresponding CLI flag (e.g. `--keys 10000`), or copy a

--- a/workloads/ycsb-e.toml
+++ b/workloads/ycsb-e.toml
@@ -1,0 +1,14 @@
+# YCSB-E — 95% short range scans / 5% inserts, Zipfian start keys.
+#
+# Models email-threading / activity-stream workloads: read a window of
+# recent records, occasionally append a new one. Each scan picks a random
+# start key (Zipfian) and a random length in [1, max_scan_length].
+
+name = "YCSB-E"
+description = "Read-mostly range scans with new-record inserts; Zipfian start keys"
+keys = 1_000_000
+value_size = 1024
+key_distribution = "zipfian"
+zipfian_theta = 0.99
+op_mix = { read = 0.0, update = 0.0, insert = 0.05, rmw = 0.0, scan = 0.95 }
+max_scan_length = 100


### PR DESCRIPTION
YCSB-E was the only workload preset we couldn't ship in earlier rounds because the engine lacked a scan API. The scan API has since landed (`LsmEngine::scan` → `impl Iterator<...>`), so the harness can now drive 95% short range scans + 5% inserts against the engine — the last YCSB gap is closed.

Workload semantics (match the YCSB paper):
  - Pick a start key per the workload's key distribution (Zipfian by default).
  - Pick a per-scan length uniformly from [1, max_scan_length], default 100.
  - Call engine.scan(Included(start), Unbounded, length) and drive the iterator to completion.

src/bin/bench.rs changes:
  - OpKind gains Scan; OpMix gains a `scan` fraction; validate() extends to include it.
  - OpSampler gains a fourth cumulative threshold (rmw_cum); scan is the residual above it. Five op kinds, no special-case dispatch.
  - Workload struct gains `max_scan_length` (default 100), wired through TOML deserialisation + CLI override.
  - New CLI flags: --scan-pct, --max-scan-length.
  - run_worker has a new Scan arm: sample start + length, build the iterator via engine.scan, drive with `for _ in iter {}`. The iterator-return shape lets us pull records lazily without materialising a ~scan_len KB Vec per op.
  - ThreadResult, WindowBucket, and the aggregation step all extend with a scans counter + scan_hist; the report adds a "scans:" row in the op breakdown and a per-op-kind latency block. The workload-header op_mix line now shows `scan=`, and `max_scan_len:` is printed when scan > 0.

The per-second CSV schema is unchanged — scans naturally show up in the existing `ops` column and the op-kind-agnostic percentile columns.

workloads/ycsb-e.toml: 95% scan / 5% insert / Zipfian θ=0.99 / max_scan_length=100 — canonical YCSB-E.

Doc updates:
  - workloads/README.md: YCSB-E row added; the "intentionally omitted" paragraph replaced with a note about scan-length sampling.
  - src/bin/README.md: dropped the "No scan workload (YCSB-E)" gap bullet; documented --scan-pct and --max-scan-length in the CLI reference.

Verification:
  - cargo test: still 160 lib + 2 main + 2 ignored stress.
  - YCSB-E smoke (3000 keys × 256B × 5s × 4 threads): 95.1% scans, 4.9% inserts, key space grew from 3000 to 7626, scans latency block populated (p50 ≈ 128µs per scan, ≈30× a single get because each scan averages ~50 records).
  - A/B/C/D/F smoke regression-check: all five report `scans: 0`, original op mixes intact, no behavioural change.

Closes #16 